### PR TITLE
Fix numeric slider not firing onChange while dragging

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -635,8 +635,10 @@ const slider = new NumericSlider(selector, options);
 | `trackTheme` | String | `null` | Override track color: `'neutral'` or `'primary'` |
 | `filledTheme` | String | `null` | Override filled track color: `'neutral'` or `'primary'` |
 | `handleTheme` | String | `null` | Override handle color: `'neutral'` or `'primary'` |
+| `continuousUpdates` | Boolean | `false` | If `true`, fires `onChange` continuously during drag (throttled by `throttleMs`). Final value always sent on drag end. |
+| `throttleMs` | Number | `16` | Throttle interval in ms for continuous updates (~60fps at 16ms). Only applies when `continuousUpdates` is `true`. |
 | `disabled` | Boolean | `false` | If `true`, disables the slider |
-| `onChange` | Function | `null` | Callback `(value, source)` when value changes via slider |
+| `onChange` | Function | `null` | Callback `(value, source)` when value changes. Fires on drag end (always), track click, keyboard, and during drag if `continuousUpdates` is `true`. |
 | `onInputChange` | Function | `null` | Callback `(value, source)` when value changes via input field |
 
 **API Methods:**
@@ -679,6 +681,18 @@ const rangeSlider = new NumericSlider('#range-slider', {
   handleTheme: 'primary',
   onChange: (values) => {
     console.log('Range:', values[0], '-', values[1]);
+  }
+});
+
+// Continuous updates during drag (for live previews)
+const liveSlider = new NumericSlider('#live-slider', {
+  type: 'single',
+  value: 50,
+  continuousUpdates: true, // Fire onChange during drag
+  throttleMs: 16, // ~60fps (default)
+  onChange: (value) => {
+    // Fires continuously while dragging (throttled) AND on drag end
+    updatePreview(value);
   }
 });
 
@@ -924,7 +938,7 @@ You can extend components using CSS custom properties:
 .my-custom-button {
   /* Inherit button styles */
   composes: button button-primary;
-  
+
   /* Override with custom properties */
   --Colors-Base-Primary-700: #custom-color;
 }

--- a/components/numeric-slider/README.md
+++ b/components/numeric-slider/README.md
@@ -71,8 +71,10 @@ const rangeSlider = new NumericSlider('#my-range-slider', {
 | `trackTheme` | String | `null` | Override track color: `'neutral'` or `'primary'`. If provided, overrides the `theme` preset for the track. |
 | `filledTheme` | String | `null` | Override filled track color: `'neutral'` or `'primary'`. If provided, overrides the `theme` preset for the filled track. |
 | `handleTheme` | String | `null` | Override handle color: `'neutral'` or `'primary'`. If provided, overrides the `theme` preset for the handles. Note: Single value sliders use marker-style handles which are always primary colored. |
+| `continuousUpdates` | Boolean | `false` | If `true`, fires `onChange` continuously during dragging (throttled by `throttleMs`). If `false` (default), `onChange` only fires on drag end, track click, and keyboard interaction. Final value is always sent on drag end regardless of this setting. |
+| `throttleMs` | Number | `16` | Throttle interval in milliseconds for continuous updates during drag (~60fps at 16ms). Only applies when `continuousUpdates` is `true`. Lower values = more frequent updates but potentially lower performance. |
 | `disabled` | Boolean | `false` | If `true`, disables the slider and all input fields. |
-| `onChange` | Function | `null` | Callback triggered when value changes via slider interaction (dragging, clicking track, keyboard). Receives `(value, source)` where `value` is the new value(s) and `source` indicates the source of change (`'min'`, `'max'`, `'single'`, or `null`). |
+| `onChange` | Function | `null` | Callback triggered when value changes. Receives `(value, source)` where `value` is the new value(s) and `source` indicates the source of change (`'min'`, `'max'`, `'single'`, or `null`). By default, fires on drag end, track click, and keyboard interaction. If `continuousUpdates` is `true`, also fires during drag (throttled). |
 | `onInputChange` | Function | `null` | Callback triggered when value changes via input field. Receives `(value, source)` where `value` is the new value(s) and `source` indicates which input changed (`'min'`, `'max'`, or `'single'`). |
 
 ## API Methods
@@ -211,6 +213,36 @@ const allPrimarySlider = new NumericSlider('#all-primary-slider', {
 });
 ```
 
+### Continuous Updates During Drag
+
+Enable continuous `onChange` callbacks while dragging (useful for live previews):
+
+```javascript
+const liveSlider = new NumericSlider('#live-slider', {
+  type: 'single',
+  value: 50,
+  continuousUpdates: true, // Fire onChange during drag
+  throttleMs: 16, // ~60fps (default)
+  onChange: (value) => {
+    // This fires continuously while dragging (throttled)
+    // AND on drag end (always)
+    document.querySelector('#preview').textContent = value;
+  }
+});
+
+// Heavier updates? Increase throttle interval
+const heavySlider = new NumericSlider('#heavy-slider', {
+  type: 'range',
+  value: [20, 80],
+  continuousUpdates: true,
+  throttleMs: 100, // 10 updates per second
+  onChange: (values) => {
+    // Expensive operation (e.g., chart re-render)
+    updateComplexVisualization(values);
+  }
+});
+```
+
 ## Interaction
 
 ### Mouse/Touch
@@ -256,7 +288,7 @@ The slider automatically validates and corrects values:
 
 The slider component includes comprehensive accessibility features:
 
-- **ARIA Attributes**: 
+- **ARIA Attributes**:
   - `role="slider"` on the slider wrapper
   - `aria-valuemin`, `aria-valuemax`, `aria-valuenow` attributes
   - `aria-label` attributes on handles and wrapper for screen readers

--- a/components/numeric-slider/numeric-slider.js
+++ b/components/numeric-slider/numeric-slider.js
@@ -356,11 +356,17 @@ class NumericSlider {
 
   endDrag() {
     if (this.isDragging) {
+      const activeHandle = this.activeHandle;
       this.isDragging = false;
       this.activeHandle = null;
       
       if (this.minHandle) this.minHandle.classList.remove('dragging');
       if (this.maxHandle) this.maxHandle.classList.remove('dragging');
+
+      // Always fire onChange on drag end with final value
+      if (this.config.onChange) {
+        this.config.onChange(this.values, activeHandle || 'single');
+      }
       if (this.handle) this.handle.classList.remove('dragging');
     }
   }

--- a/components/numeric-slider/numeric-slider.js
+++ b/components/numeric-slider/numeric-slider.js
@@ -5,20 +5,20 @@
 
 class NumericSlider {
   constructor(container, options = {}) {
-    this.container = typeof container === 'string' 
-      ? document.querySelector(container) 
+    this.container = typeof container === 'string'
+      ? document.querySelector(container)
       : container;
-    
+
     if (!this.container) {
       throw new Error('NumericSlider container not found');
     }
 
     // Configuration
     const defaultTheme = options.theme || 'default';
-    
+
     // Determine theme values - allow individual overrides or use theme preset
     let trackTheme, filledTheme, handleTheme;
-    
+
     if (options.trackTheme !== undefined || options.filledTheme !== undefined || options.handleTheme !== undefined) {
       // Individual overrides provided
       trackTheme = options.trackTheme || (defaultTheme === 'primary' ? 'primary' : 'neutral');
@@ -37,7 +37,7 @@ class NumericSlider {
         handleTheme = 'primary';
       }
     }
-    
+
     this.config = {
       type: options.type || 'single', // 'single' or 'range'
       min: options.min !== undefined ? options.min : 0,
@@ -49,6 +49,8 @@ class NumericSlider {
       trackTheme: trackTheme, // 'neutral' or 'primary'
       filledTheme: filledTheme, // 'neutral' or 'primary'
       handleTheme: handleTheme, // 'neutral' or 'primary'
+      continuousUpdates: options.continuousUpdates !== undefined ? options.continuousUpdates : false, // Fire onChange during drag
+      throttleMs: options.throttleMs !== undefined ? options.throttleMs : 16, // Throttle interval (~60fps)
       onChange: options.onChange || null,
       onInputChange: options.onInputChange || null,
       disabled: options.disabled || false,
@@ -60,10 +62,11 @@ class NumericSlider {
     this.activeHandle = null;
     this.startX = 0;
     this.startValue = null;
+    this.lastCallbackTime = 0; // For throttling continuous updates
 
     // Initialize values
     if (this.config.type === 'range') {
-      this.values = Array.isArray(this.config.value) 
+      this.values = Array.isArray(this.config.value)
         ? [Math.max(this.config.min, this.config.value[0]), Math.min(this.config.max, this.config.value[1])]
         : [this.config.min, this.config.max];
       // Ensure min <= max
@@ -84,12 +87,12 @@ class NumericSlider {
     // Create slider structure
     this.container.innerHTML = '';
     this.container.className = 'numeric-slider-container';
-    
+
     // Keep theme-primary class for backward compatibility
     if (this.config.theme === 'primary') {
       this.container.classList.add('theme-primary');
     }
-    
+
     if (this.config.disabled) {
       this.container.classList.add('disabled');
     }
@@ -142,7 +145,7 @@ class NumericSlider {
     this.wrapper.setAttribute('aria-valuemin', this.config.min);
     this.wrapper.setAttribute('aria-valuemax', this.config.max);
     this.wrapper.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
-    
+
     if (this.config.type === 'range') {
       this.wrapper.setAttribute('aria-valuenow', `${this.values[0]},${this.values[1]}`);
       this.wrapper.setAttribute('aria-label', `Range slider from ${this.values[0]} to ${this.values[1]}`);
@@ -157,14 +160,14 @@ class NumericSlider {
     if (this.config.trackTheme === 'primary') {
       this.track.classList.add('theme-primary');
     }
-    
+
     // Create filled track
     this.filled = document.createElement('div');
     this.filled.className = 'numeric-slider-filled';
     if (this.config.filledTheme === 'primary') {
       this.filled.classList.add('theme-primary');
     }
-    
+
     // Create handles
     if (this.config.type === 'range') {
       // Min handle
@@ -177,7 +180,7 @@ class NumericSlider {
       this.minHandle.setAttribute('aria-label', `Minimum value: ${this.values[0]}`);
       this.minHandle.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
       this.minHandle.disabled = this.config.disabled;
-      
+
       // Max handle
       this.maxHandle = document.createElement('button');
       this.maxHandle.className = 'numeric-slider-handle';
@@ -188,7 +191,7 @@ class NumericSlider {
       this.maxHandle.setAttribute('aria-label', `Maximum value: ${this.values[1]}`);
       this.maxHandle.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
       this.maxHandle.disabled = this.config.disabled;
-      
+
       this.track.appendChild(this.filled);
       this.track.appendChild(this.minHandle);
       this.track.appendChild(this.maxHandle);
@@ -203,11 +206,11 @@ class NumericSlider {
       this.handle.setAttribute('aria-label', `Value: ${this.values}`);
       this.handle.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
       this.handle.disabled = this.config.disabled;
-      
+
       this.track.appendChild(this.filled);
       this.track.appendChild(this.handle);
     }
-    
+
     this.wrapper.appendChild(this.track);
     this.container.appendChild(this.wrapper);
 
@@ -299,7 +302,7 @@ class NumericSlider {
       // Determine which handle is closer
       const minDist = Math.abs(snappedValue - this.values[0]);
       const maxDist = Math.abs(snappedValue - this.values[1]);
-      
+
       if (minDist < maxDist) {
         this.setValue([snappedValue, this.values[1]], 'min');
       } else {
@@ -312,14 +315,14 @@ class NumericSlider {
 
   startDrag(e, handleType) {
     if (this.config.disabled) return;
-    
+
     e.preventDefault();
     e.stopPropagation();
-    
+
     this.isDragging = true;
     this.activeHandle = handleType;
     this.startX = e.clientX || (e.touches && e.touches[0].clientX);
-    
+
     if (handleType === 'min') {
       this.startValue = this.values[0];
       this.minHandle.classList.add('dragging');
@@ -334,23 +337,31 @@ class NumericSlider {
 
   handleDrag(e) {
     if (!this.isDragging || !this.activeHandle) return;
-    
+
     e.preventDefault();
-    
+
     const rect = this.track.getBoundingClientRect();
     const x = e.clientX || (e.touches && e.touches[0].clientX);
     const percent = Math.max(0, Math.min(1, (x - rect.left) / rect.width));
     const newValue = this.config.min + percent * (this.config.max - this.config.min);
     const snappedValue = this.snapToStep(newValue);
 
+    // Determine if we should trigger callback based on continuousUpdates and throttling
+    const shouldTrigger = this.config.continuousUpdates &&
+      (Date.now() - this.lastCallbackTime >= this.config.throttleMs);
+
+    if (shouldTrigger) {
+      this.lastCallbackTime = Date.now();
+    }
+
     if (this.activeHandle === 'min') {
       const newMin = Math.max(this.config.min, Math.min(snappedValue, this.values[1]));
-      this.setValue([newMin, this.values[1]], 'min', false);
+      this.setValue([newMin, this.values[1]], 'min', shouldTrigger);
     } else if (this.activeHandle === 'max') {
       const newMax = Math.min(this.config.max, Math.max(snappedValue, this.values[0]));
-      this.setValue([this.values[0], newMax], 'max', false);
+      this.setValue([this.values[0], newMax], 'max', shouldTrigger);
     } else {
-      this.setValue(snappedValue, 'single', false);
+      this.setValue(snappedValue, 'single', shouldTrigger);
     }
   }
 
@@ -359,23 +370,23 @@ class NumericSlider {
       const activeHandle = this.activeHandle;
       this.isDragging = false;
       this.activeHandle = null;
-      
+
       if (this.minHandle) this.minHandle.classList.remove('dragging');
       if (this.maxHandle) this.maxHandle.classList.remove('dragging');
+      if (this.handle) this.handle.classList.remove('dragging');
 
       // Always fire onChange on drag end with final value
       if (this.config.onChange) {
         this.config.onChange(this.values, activeHandle || 'single');
       }
-      if (this.handle) this.handle.classList.remove('dragging');
     }
   }
 
   handleInputChange(e, handleType) {
     const value = parseFloat(e.target.value);
-    
+
     if (isNaN(value)) return;
-    
+
     if (handleType === 'min') {
       const newMin = Math.max(this.config.min, Math.min(value, this.values[1]));
       this.setValue([newMin, this.values[1]], 'min');
@@ -390,7 +401,7 @@ class NumericSlider {
 
   handleInputBlur(e, handleType) {
     const value = parseFloat(e.target.value);
-    
+
     if (isNaN(value)) {
       // Reset to current value if invalid
       if (handleType === 'min') {
@@ -420,10 +431,10 @@ class NumericSlider {
 
   handleKeyDown(e, handleType) {
     if (this.config.disabled) return;
-    
+
     const step = e.shiftKey ? this.config.step * 10 : this.config.step;
     let newValue;
-    
+
     if (this.config.type === 'range') {
       if (handleType === 'min') {
         if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
@@ -457,7 +468,7 @@ class NumericSlider {
         this.setValue(newValue);
       }
     }
-    
+
     if (e.key === 'Home') {
       e.preventDefault();
       if (this.config.type === 'range' && handleType === 'min') {
@@ -485,25 +496,25 @@ class NumericSlider {
 
   updateVisuals() {
     const range = this.config.max - this.config.min;
-    
+
     if (this.config.type === 'range') {
       const minPercent = ((this.values[0] - this.config.min) / range) * 100;
       const maxPercent = ((this.values[1] - this.config.min) / range) * 100;
-      
+
       // Position handles
       this.minHandle.style.left = `${minPercent}%`;
       this.maxHandle.style.left = `${maxPercent}%`;
-      
+
       // Update filled track
       this.filled.style.left = `${minPercent}%`;
       this.filled.style.width = `${maxPercent - minPercent}%`;
-      
+
       // Update inputs
       if (this.config.showInputs) {
         this.minInput.value = Math.round(this.values[0]);
         this.maxInput.value = Math.round(this.values[1]);
       }
-      
+
       // Update aria attributes
       this.wrapper.setAttribute('aria-valuenow', `${this.values[0]},${this.values[1]}`);
       this.wrapper.setAttribute('aria-label', `Range slider from ${this.values[0]} to ${this.values[1]}`);
@@ -511,19 +522,19 @@ class NumericSlider {
       this.maxHandle.setAttribute('aria-label', `Maximum value: ${this.values[1]}`);
     } else {
       const percent = ((this.values - this.config.min) / range) * 100;
-      
+
       // Position handle
       this.handle.style.left = `${percent}%`;
-      
+
       // Update filled track
       this.filled.style.left = '0%';
       this.filled.style.width = `${percent}%`;
-      
+
       // Update input
       if (this.config.showInputs) {
         this.valueInput.value = Math.round(this.values);
       }
-      
+
       // Update aria attributes
       this.wrapper.setAttribute('aria-valuenow', this.values);
       this.wrapper.setAttribute('aria-label', `Slider value ${this.values}`);
@@ -547,13 +558,13 @@ class NumericSlider {
     } else {
       this.values = Math.max(this.config.min, Math.min(this.config.max, value));
     }
-    
+
     this.updateVisuals();
-    
+
     if (triggerCallback && this.config.onChange) {
       this.config.onChange(this.values, source);
     }
-    
+
     if (triggerCallback && this.config.onInputChange && source) {
       this.config.onInputChange(this.values, source);
     }
@@ -565,7 +576,7 @@ class NumericSlider {
 
   setDisabled(disabled) {
     this.config.disabled = disabled;
-    
+
     if (disabled) {
       this.container.classList.add('disabled');
       this.wrapper.setAttribute('tabindex', '-1');

--- a/components/numeric-slider/test.html
+++ b/components/numeric-slider/test.html
@@ -236,6 +236,24 @@
       </div>
     </div>
 
+    <!-- Continuous Updates -->
+    <div class="test-section">
+      <h2>Continuous Updates</h2>
+      <div class="test-row">
+        <div class="test-item">
+          <label>Setting continuousUpdates to true will fire onChange during drag</label>
+          <div class="slider-wrapper">
+            <div id="slider-continuous"></div>
+          </div>
+        </div>
+      </div>
+      <div class="test-output">
+        <strong>Value:</strong> <span id="output-continuous">50</span>
+        <br>
+        <strong>Update count:</strong> <span id="output-continuous-count">0</span>
+      </div>
+    </div>
+
     <!-- Disabled State -->
     <div class="test-section">
       <h2>Disabled State</h2>
@@ -356,6 +374,21 @@
       }
     });
 
+    // Continuous updates
+    let continuousUpdateCount = 0;
+    const sliderContinuous = new NumericSlider('#slider-continuous', {
+      type: 'single',
+      value: 50,
+      showInputs: true,
+      continuousUpdates: true,
+      throttleMs: 16, // ~60fps
+      onChange: (value) => {
+        continuousUpdateCount++;
+        document.getElementById('output-continuous').textContent = Math.round(value);
+        document.getElementById('output-continuous-count').textContent = continuousUpdateCount;
+      }
+    });
+
     // Disabled sliders
     new NumericSlider('#slider-disabled-single', {
       type: 'single',
@@ -382,7 +415,8 @@
       customRange: sliderCustomRange,
       negativeRange: sliderNegativeRange,
       presetSingle: sliderPresetSingle,
-      presetRange: sliderPresetRange
+      presetRange: sliderPresetRange,
+      continuous: sliderContinuous
     };
   </script>
 </body>

--- a/test.html
+++ b/test.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="typography/typography.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <!-- <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"> -->
+    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
         html, body {
             height: 100%;

--- a/test.html
+++ b/test.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="typography/typography.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"> -->
     <style>
         html, body {
             height: 100%;


### PR DESCRIPTION
This PR addresses #2 by:
- Always firing `onChange` callback in `endDrag`
- Introducing `continuousUpdates` parameter that makes `onChange` fire during `handleDrag` as well (with throttling), disabled by default
- Updates the test harness to show the `continuousUpdates = true` variant

Before:

https://github.com/user-attachments/assets/dcb9c5e7-3dd4-4ae9-8ea5-5f42a7f0840f

After:

https://github.com/user-attachments/assets/ca6d122d-f932-4d55-93b1-0d5e89a4fcf6

https://github.com/user-attachments/assets/a0afa729-208d-4aa0-8348-ae8f3b49b952

