### PR TITLE
Add reusable table styles for markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Reusable UI elements built using the foundations.
 - **[Modal](components/modal/README.md)** ([CSS](components/modal/modal.css), [JS](components/modal/modal.js)): Customizable modal dialogs with flexible content insertion. Includes a help modal variant optimized for documentation.
 - **[Numeric Slider](components/numeric-slider/README.md)** ([CSS](components/numeric-slider/numeric-slider.css), [JS](components/numeric-slider/numeric-slider.js)): Single value and range sliders with optional input fields.
 - **[Split Panel](components/split-panel/README.md)** ([CSS](components/split-panel/split-panel.css), [JS](components/split-panel/split-panel.js)): Resizable split panel component with draggable divider for horizontal or vertical layouts.
+- **[Table](components/table/README.md)** ([CSS](components/table/table.css)): Editorial, read-only table layout with a scroll wrapper for horizontal overflow on small screens.
 - **[Tags](components/tags/README.md)** ([CSS](components/tags/tags.css)): Label and status indicator tags.
 
 ## Usage
@@ -59,6 +60,7 @@ Include the relevant CSS files in your HTML. For a full integration, you typical
 <link rel="stylesheet" href="/design-system/components/modal/modal.css">
 <link rel="stylesheet" href="/design-system/components/numeric-slider/numeric-slider.css">
 <link rel="stylesheet" href="/design-system/components/split-panel/split-panel.css">
+<link rel="stylesheet" href="/design-system/components/table/table.css">
 <link rel="stylesheet" href="/design-system/components/tags/tags.css">
 ```
 

--- a/agents.md
+++ b/agents.md
@@ -52,6 +52,7 @@ The CodeSignal Design System is a CSS-based design system organized into **Found
 <link rel="stylesheet" href="/design-system/components/modal/modal.css">
 <link rel="stylesheet" href="/design-system/components/numeric-slider/numeric-slider.css">
 <link rel="stylesheet" href="/design-system/components/split-panel/split-panel.css">
+<link rel="stylesheet" href="/design-system/components/table/table.css">
 <link rel="stylesheet" href="/design-system/components/tags/tags.css">
 ```
 
@@ -512,6 +513,43 @@ Radio buttons require a specific HTML structure and must share the same `name` a
 <div class="tag error">Failed</div>
 <div class="tag outline">Filter</div>
 ```
+
+**Dependencies:** colors.css, spacing.css, typography.css
+
+---
+
+### Table
+
+**Structure:** Use a scroll wrapper so wide tables can overflow horizontally on small screens.
+
+**Classes:**
+- `.table-scroll` (required wrapper): Block container with border, radius, horizontal scrolling, and touch-friendly overflow
+- `.table` (required on `<table>`): Base typography, borders, and cell padding for editorial, read-only tables
+
+**Example:**
+```html
+<div class="table-scroll">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Country</th>
+        <th>Capital</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>France</td>
+        <td>Paris</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+**Features:**
+- Header and body cell styling with semantic color tokens (dark mode via `prefers-color-scheme`)
+- Last row has no bottom border; top corners of the header align with the wrapper radius
+- `<code>` inside cells uses `white-space: nowrap` for inline snippets
 
 **Dependencies:** colors.css, spacing.css, typography.css
 
@@ -1172,6 +1210,10 @@ design-system/
 │   ├── split-panel/
 │   │   ├── split-panel.css
 │   │   ├── split-panel.js
+│   │   ├── README.md
+│   │   └── test.html
+│   ├── table/
+│   │   ├── table.css
 │   │   ├── README.md
 │   │   └── test.html
 │   └── tags/

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -1,0 +1,52 @@
+# Table Component
+
+A reusable table presentation layer matching the CodeSignal Design System.
+
+## Usage
+
+Import the CSS file in your HTML or CSS:
+
+```html
+<link rel="stylesheet" href="/design-system/components/table/table.css">
+```
+
+or
+
+```css
+@import url('/design-system/components/table/table.css');
+```
+
+## Structure
+
+Tables use a scroll wrapper so wide content can overflow horizontally on small screens:
+
+```html
+<div class="table-scroll">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Country</th>
+        <th>Capital</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>France</td>
+        <td>Paris</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+## Classes
+
+- `.table-scroll`: Overflow wrapper with border, radius, and horizontal scrolling.
+- `.table`: Base table styling for editorial and read-only tables.
+
+## Dependencies
+
+This component relies on variables from:
+- `design-system/colors/colors.css`
+- `design-system/spacing/spacing.css`
+- `design-system/typography/typography.css`

--- a/components/table/table.css
+++ b/components/table/table.css
@@ -5,50 +5,68 @@
   margin: 1em 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  border: 1px solid var(--Colors-Stroke-Default);
+  border: 1.5px solid var(--Colors-Border-Neutral-Default, rgba(103, 113, 142, 0.20));
   border-radius: var(--UI-Radius-radius-s, 8px);
   background: var(--Colors-Backgrounds-Main-Top);
 }
 
 .table {
+  min-width: 100%;
   width: max-content;
   border-collapse: separate;
   border-spacing: 0;
   background: var(--Colors-Backgrounds-Main-Top);
   color: var(--Colors-Text-Body-Default);
-}
-
-.table thead {
-  background: var(--Colors-Backgrounds-Main-Medium);
+  font-family: var(--body-family);
 }
 
 .table th,
 .table td {
-  padding: var(--UI-Spacing-spacing-mxs, 12px) var(--UI-Spacing-spacing-ms, 16px);
+  min-height: 53px;
+  padding: var(--UI-Spacing-spacing-xs, 6px) calc(var(--UI-Spacing-spacing-mxs, 12px) + var(--UI-Spacing-spacing-xs, 6px));
   text-align: left;
-  vertical-align: top;
-  border-right: 1px solid var(--Colors-Stroke-Default);
-  border-bottom: 1px solid var(--Colors-Stroke-Default);
+  vertical-align: middle;
+  border-bottom: 1.5px solid var(--Colors-Border-Neutral-Subtle, rgba(103, 113, 142, 0.10));
+  white-space: nowrap;
 }
 
 .table th {
+  font-family: var(--body-family);
+  font-size: var(--Fonts-Body-Default-xs, 14px);
+  line-height: 140%;
+  letter-spacing: -0.21px;
   color: var(--Colors-Text-Body-Strong);
-  font-weight: 500;
+  font-style: normal;
+  font-weight: 600;
   -webkit-font-smoothing: antialiased;
+  text-transform: capitalize;
 }
 
 .table td {
+  font-family: var(--body-family);
+  font-size: var(--Fonts-Body-Default-sm, 15px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 135%;
+  letter-spacing: -0.15px;
   color: var(--Colors-Text-Body-Default);
 }
 
-.table th:last-child,
-.table td:last-child {
-  border-right: none;
+.table thead th {
+  border-bottom-color: var(--Colors-Border-Neutral-Subtle, rgba(103, 113, 142, 0.10));
 }
 
 .table tbody tr:last-child th,
 .table tbody tr:last-child td {
   border-bottom: none;
+}
+
+.table thead tr:first-child th:first-child {
+  border-top-left-radius: calc(var(--UI-Radius-radius-s, 8px) - 1px);
+}
+
+.table thead tr:first-child th:last-child {
+  border-top-right-radius: calc(var(--UI-Radius-radius-s, 8px) - 1px);
 }
 
 .table code {

--- a/components/table/table.css
+++ b/components/table/table.css
@@ -5,7 +5,7 @@
   margin: 1em 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  border: 1.5px solid var(--Colors-Border-Neutral-Default, rgba(103, 113, 142, 0.20));
+  border: 1.5px solid var(--Colors-Stroke-Default);
   border-radius: var(--UI-Radius-radius-s, 8px);
   background: var(--Colors-Backgrounds-Main-Top);
 }
@@ -26,7 +26,7 @@
   padding: var(--UI-Spacing-spacing-xs, 6px) calc(var(--UI-Spacing-spacing-mxs, 12px) + var(--UI-Spacing-spacing-xs, 6px));
   text-align: left;
   vertical-align: middle;
-  border-bottom: 1.5px solid var(--Colors-Border-Neutral-Subtle, rgba(103, 113, 142, 0.10));
+  border-bottom: 1.5px solid var(--Colors-Stroke-Lighter);
   white-space: nowrap;
 }
 
@@ -53,7 +53,7 @@
 }
 
 .table thead th {
-  border-bottom-color: var(--Colors-Border-Neutral-Subtle, rgba(103, 113, 142, 0.10));
+  border-bottom-color: var(--Colors-Stroke-Lighter);
 }
 
 .table tbody tr:last-child th,

--- a/components/table/table.css
+++ b/components/table/table.css
@@ -1,0 +1,56 @@
+.table-scroll {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin: 1em 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid var(--Colors-Stroke-Default);
+  border-radius: var(--UI-Radius-radius-s, 8px);
+  background: var(--Colors-Backgrounds-Main-Top);
+}
+
+.table {
+  width: max-content;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--Colors-Backgrounds-Main-Top);
+  color: var(--Colors-Text-Body-Default);
+}
+
+.table thead {
+  background: var(--Colors-Backgrounds-Main-Medium);
+}
+
+.table th,
+.table td {
+  padding: var(--UI-Spacing-spacing-mxs, 12px) var(--UI-Spacing-spacing-ms, 16px);
+  text-align: left;
+  vertical-align: top;
+  border-right: 1px solid var(--Colors-Stroke-Default);
+  border-bottom: 1px solid var(--Colors-Stroke-Default);
+}
+
+.table th {
+  color: var(--Colors-Text-Body-Strong);
+  font-weight: 500;
+  -webkit-font-smoothing: antialiased;
+}
+
+.table td {
+  color: var(--Colors-Text-Body-Default);
+}
+
+.table th:last-child,
+.table td:last-child {
+  border-right: none;
+}
+
+.table tbody tr:last-child th,
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table code {
+  white-space: nowrap;
+}

--- a/components/table/test.html
+++ b/components/table/test.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Table Component Test</title>
+    <link rel="stylesheet" href="../../colors/colors.css">
+    <link rel="stylesheet" href="../../spacing/spacing.css">
+    <link rel="stylesheet" href="../../typography/typography.css">
+    <link rel="stylesheet" href="table.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            padding: 40px;
+            background-color: var(--Colors-Backgrounds-Main-Default);
+            font-family: var(--body-family);
+            color: var(--Colors-Text-Body-Default);
+        }
+
+        .section {
+            margin-bottom: 40px;
+        }
+
+        h1 {
+            margin-bottom: 24px;
+            color: var(--Colors-Text-Body-Strong);
+        }
+
+        h2 {
+            margin-bottom: 16px;
+            font-size: 1.2rem;
+            color: var(--Colors-Text-Body-Strong);
+        }
+
+        .variant-card {
+            padding: 24px;
+            border: 1px solid var(--Colors-Stroke-Default);
+            border-radius: 8px;
+            background: var(--Colors-Backgrounds-Main-Top);
+            margin-bottom: 24px;
+        }
+
+        .demo-copy {
+            margin-bottom: 16px;
+        }
+
+        .demo-constrained {
+            max-width: 420px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Table Component Test</h1>
+
+    <div class="section">
+        <h2>Editorial Table</h2>
+        <div class="variant-card">
+            <p class="demo-copy">Reference table styled for markdown-rendered content.</p>
+            <div class="table-scroll">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Country</th>
+                            <th>Capital</th>
+                            <th>Helpful Note</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>France</td>
+                            <td>Paris</td>
+                            <td>Remember <code>Île-de-France</code> for the surrounding region.</td>
+                        </tr>
+                        <tr>
+                            <td>Japan</td>
+                            <td>Tokyo</td>
+                            <td>Largest metropolitan area in the world.</td>
+                        </tr>
+                        <tr>
+                            <td>Brazil</td>
+                            <td>Brasília</td>
+                            <td>Purpose-built capital city.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Overflow In A Narrow Column</h2>
+        <div class="variant-card demo-constrained">
+            <p class="demo-copy">The wrapper should shrink to content when possible and scroll only when needed.</p>
+            <div class="table-scroll">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Planet</th>
+                            <th>Average Distance From The Sun</th>
+                            <th>Surface Gravity</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Mercury</td>
+                            <td>57,910,000 km</td>
+                            <td>3.7 m/s²</td>
+                        </tr>
+                        <tr>
+                            <td>Earth</td>
+                            <td>149,600,000 km</td>
+                            <td>9.8 m/s²</td>
+                        </tr>
+                        <tr>
+                            <td>Neptune</td>
+                            <td>4,495,100,000 km</td>
+                            <td>11.2 m/s²</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/llms.txt
+++ b/llms.txt
@@ -66,6 +66,12 @@ Also include Work Sans font from Google Fonts.
 - States: `.hover`, `.focus`, `.active`
 - Example: `<div class="tag success">Completed</div>`
 
+### Table
+- Structure: Wrap `<table class="table">` in `<div class="table-scroll">` for horizontal scrolling on narrow viewports
+- Classes: `.table-scroll` (border, radius, overflow-x), `.table` (cell typography, row borders, editorial styling)
+- Example: `<div class="table-scroll"><table class="table"><thead><tr><th>…</th></tr></thead><tbody><tr><td>…</td></tr></tbody></table></div>`
+- CSS-only (no JS)
+
 ### Icon
 - Base: `.icon`
 - Icon names: `.icon-[name]` (e.g., `.icon-jobs`, `.icon-academy`)
@@ -134,6 +140,7 @@ design-system/
     ├── modal/modal.css + modal.js
     ├── numeric-slider/numeric-slider.css + numeric-slider.js
     ├── split-panel/split-panel.css + split-panel.js
+    ├── table/table.css
     └── tags/tags.css
 ```
 

--- a/test.html
+++ b/test.html
@@ -117,6 +117,7 @@
                     <li><a href="components/modal/test.html" target="content-frame">Modal</a></li>
                     <li><a href="components/numeric-slider/test.html" target="content-frame">Numeric Slider</a></li>
                     <li><a href="components/split-panel/test.html" target="content-frame">Split Panel</a></li>
+                    <li><a href="components/table/test.html" target="content-frame">Table</a></li>
                     <li><a href="components/tags/test.html" target="content-frame">Tags</a></li>
                 </ul>
             </div>
@@ -188,4 +189,3 @@
     </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary

Adds a reusable table stylesheet to the design system so Markdown-rendered tables in Learn activities can consume shared styles from the submodule instead of defining table presentation in the app repo.

This is the design-system half of the Markdown table support work for Learn activities.

## What changed

- Added `components/table/table.css`
- Added `components/table/README.md`
- Added `components/table/test.html`
- Added the table component to the design-system test bed navigation in `test.html`

## Why

This PR provides a shared stylesheet so the bespoke simulations can:
- render Markdown tables with design-system classes
- reuse the same table styling in both the main app and iframe-rendered Markdown
- avoid duplicating table CSS

## Scope

This PR covers the reusable styling asset only.

It does not add JS table behavior or pagination/footer logic. The current target is editorial/Markdown table rendering, not a fully interactive data table component.

## Notes

- The current styling is a close approximation of the Figma design and can be refined further in follow-up iterations without changing the app-side integration.
- Linked app PR consuming this stylesheet: https://github.com/CodeSignal/learn_cosmo-activities-web/pull/8