### PR TITLE
fix(a11y): trap focus inside open modals

### DIFF
--- a/components/modal/README.md
+++ b/components/modal/README.md
@@ -402,9 +402,9 @@ Footer buttons support the following types:
 The modal component includes:
 
 - **ARIA Attributes**: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
-- **Focus Management**: Automatically focuses close button or title when opened
+- **Focus Management**: Focuses the close button (or title / dialog) on open, and restores focus to the invoking element on close
 - **Keyboard Navigation**: Escape key closes modal
-- **Focus Trap**: Focus is managed within the modal
+- **Focus Trap**: Tab and Shift+Tab cycle only among focusable elements inside the dialog; background siblings are marked `inert` while open
 - **Body Scroll Lock**: Prevents background scrolling when modal is open
 
 ## Dependencies

--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -23,6 +23,7 @@ class Modal {
     this.isOpen = false;
     this.previousActiveElement = null;
     this.bodyScrollLocked = false;
+    this.inertedSiblings = [];
 
     // Create modal structure
     this.init();
@@ -199,6 +200,10 @@ class Modal {
       document.addEventListener('keydown', this.escapeHandler);
     }
 
+    // Focus trap — keep Tab / Shift+Tab cycling inside the dialog
+    this.focusTrapHandler = (e) => this.handleFocusTrapKeydown(e);
+    document.addEventListener('keydown', this.focusTrapHandler, true);
+
     // Prevent dialog clicks from closing modal
     this.dialog.addEventListener('click', (e) => {
       e.stopPropagation();
@@ -228,14 +233,21 @@ class Modal {
     this.overlay.classList.add('open');
     this.overlay.setAttribute('aria-hidden', 'false');
 
-    // Lock body scroll
+    // Lock body scroll and remove background from the keyboard / AT tree
     this.lockBodyScroll();
+    this.setBackgroundInert(true);
 
     // Focus management
     if (this.closeButton) {
       this.closeButton.focus();
     } else if (this.title) {
+      if (!this.title.hasAttribute('tabindex')) {
+        this.title.setAttribute('tabindex', '-1');
+      }
       this.title.focus();
+    } else {
+      this.overlay.setAttribute('tabindex', '-1');
+      this.overlay.focus();
     }
 
     // Call onOpen callback
@@ -253,8 +265,9 @@ class Modal {
     this.overlay.classList.remove('open');
     this.overlay.setAttribute('aria-hidden', 'true');
 
-    // Unlock body scroll
+    // Unlock body scroll and restore background interactivity
     this.unlockBodyScroll();
+    this.setBackgroundInert(false);
 
     // Restore focus
     if (this.previousActiveElement) {
@@ -265,6 +278,75 @@ class Modal {
     if (this.config.onClose) {
       this.config.onClose(this);
     }
+  }
+
+  /**
+   * Focusable descendants inside the dialog, in tab order.
+   * Excludes disabled, aria-hidden, and visually non-rendered controls.
+   */
+  getFocusableElements() {
+    const selector = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled]):not([type="hidden"])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(', ');
+
+    return Array.from(this.overlay.querySelectorAll(selector)).filter((el) => {
+      if (el.disabled || el.getAttribute('aria-hidden') === 'true') return false;
+      if (el.closest('[inert]')) return false;
+      return el.getClientRects().length > 0;
+    });
+  }
+
+  handleFocusTrapKeydown(e) {
+    if (!this.isOpen || e.key !== 'Tab') return;
+
+    const focusable = this.getFocusableElements();
+    if (focusable.length === 0) {
+      e.preventDefault();
+      this.overlay.setAttribute('tabindex', '-1');
+      this.overlay.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    const focusInside = this.overlay.contains(active);
+
+    if (e.shiftKey) {
+      if (!focusInside || active === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (!focusInside || active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  /**
+   * Mark every body child except this overlay as inert so keyboard and
+   * assistive technology cannot reach the page behind the dialog.
+   */
+  setBackgroundInert(enabled) {
+    if (enabled) {
+      this.inertedSiblings = [];
+      Array.from(document.body.children).forEach((child) => {
+        if (child === this.overlay || child.inert) return;
+        child.inert = true;
+        this.inertedSiblings.push(child);
+      });
+      return;
+    }
+
+    this.inertedSiblings.forEach((child) => {
+      child.inert = false;
+    });
+    this.inertedSiblings = [];
   }
 
   lockBodyScroll() {
@@ -316,9 +398,13 @@ class Modal {
     if (this.escapeHandler) {
       document.removeEventListener('keydown', this.escapeHandler);
     }
+    if (this.focusTrapHandler) {
+      document.removeEventListener('keydown', this.focusTrapHandler, true);
+    }
 
-    // Unlock body scroll if still locked
+    // Unlock body scroll / inert if still applied
     this.unlockBodyScroll();
+    this.setBackgroundInert(false);
 
     // Remove from DOM
     if (this.overlay && this.overlay.parentNode) {

--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -3,6 +3,51 @@
  * A customizable modal component matching the CodeSignal Design System
  */
 
+/** Open modals, bottom → top. Only the top overlay stays interactive. */
+const openModalStack = [];
+/** Prior `inert` values for body children we have touched, restored when the stack empties. */
+const priorInertByElement = new Map();
+
+function rememberPriorInert(el) {
+  if (!priorInertByElement.has(el)) {
+    priorInertByElement.set(el, el.inert);
+  }
+}
+
+function syncModalBackgroundInert() {
+  const top = openModalStack[openModalStack.length - 1];
+
+  if (!top) {
+    priorInertByElement.forEach((prior, el) => {
+      if (el.isConnected) el.inert = prior;
+    });
+    priorInertByElement.clear();
+    return;
+  }
+
+  Array.from(document.body.children).forEach((child) => {
+    rememberPriorInert(child);
+    child.inert = child !== top.overlay;
+  });
+
+  for (const el of [...priorInertByElement.keys()]) {
+    if (!el.isConnected) priorInertByElement.delete(el);
+  }
+}
+
+function pushOpenModal(modal) {
+  const idx = openModalStack.indexOf(modal);
+  if (idx !== -1) openModalStack.splice(idx, 1);
+  openModalStack.push(modal);
+  syncModalBackgroundInert();
+}
+
+function popOpenModal(modal) {
+  const idx = openModalStack.indexOf(modal);
+  if (idx !== -1) openModalStack.splice(idx, 1);
+  syncModalBackgroundInert();
+}
+
 class Modal {
   constructor(options = {}) {
     // Configuration
@@ -23,7 +68,6 @@ class Modal {
     this.isOpen = false;
     this.previousActiveElement = null;
     this.bodyScrollLocked = false;
-    this.inertedSiblings = [];
 
     // Create modal structure
     this.init();
@@ -235,7 +279,7 @@ class Modal {
 
     // Lock body scroll and remove background from the keyboard / AT tree
     this.lockBodyScroll();
-    this.setBackgroundInert(true);
+    pushOpenModal(this);
 
     // Focus management
     if (this.closeButton) {
@@ -267,7 +311,7 @@ class Modal {
 
     // Unlock body scroll and restore background interactivity
     this.unlockBodyScroll();
-    this.setBackgroundInert(false);
+    popOpenModal(this);
 
     // Restore focus
     if (this.previousActiveElement) {
@@ -303,6 +347,8 @@ class Modal {
 
   handleFocusTrapKeydown(e) {
     if (!this.isOpen || e.key !== 'Tab') return;
+    // Only the topmost open modal owns the trap
+    if (openModalStack[openModalStack.length - 1] !== this) return;
 
     const focusable = this.getFocusableElements();
     if (focusable.length === 0) {
@@ -316,37 +362,18 @@ class Modal {
     const last = focusable[focusable.length - 1];
     const active = document.activeElement;
     const focusInside = this.overlay.contains(active);
+    // e.g. title/overlay focused with tabindex="-1" — in the dialog but not in tab order
+    const insideButNotFocusable = focusInside && !focusable.includes(active);
 
     if (e.shiftKey) {
-      if (!focusInside || active === first) {
+      if (!focusInside || active === first || insideButNotFocusable) {
         e.preventDefault();
         last.focus();
       }
-    } else if (!focusInside || active === last) {
+    } else if (!focusInside || active === last || insideButNotFocusable) {
       e.preventDefault();
       first.focus();
     }
-  }
-
-  /**
-   * Mark every body child except this overlay as inert so keyboard and
-   * assistive technology cannot reach the page behind the dialog.
-   */
-  setBackgroundInert(enabled) {
-    if (enabled) {
-      this.inertedSiblings = [];
-      Array.from(document.body.children).forEach((child) => {
-        if (child === this.overlay || child.inert) return;
-        child.inert = true;
-        this.inertedSiblings.push(child);
-      });
-      return;
-    }
-
-    this.inertedSiblings.forEach((child) => {
-      child.inert = false;
-    });
-    this.inertedSiblings = [];
   }
 
   lockBodyScroll() {
@@ -403,8 +430,11 @@ class Modal {
     }
 
     // Unlock body scroll / inert if still applied
+    if (this.isOpen) {
+      this.isOpen = false;
+      popOpenModal(this);
+    }
     this.unlockBodyScroll();
-    this.setBackgroundInert(false);
 
     // Remove from DOM
     if (this.overlay && this.overlay.parentNode) {

--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -7,6 +7,8 @@
 const openModalStack = [];
 /** Prior `inert` values for body children we have touched, restored when the stack empties. */
 const priorInertByElement = new Map();
+/** Single observer for body children added while any modal is open. */
+let bodyInertObserver = null;
 
 function rememberPriorInert(el) {
   if (!priorInertByElement.has(el)) {
@@ -14,16 +16,42 @@ function rememberPriorInert(el) {
   }
 }
 
+function ensureBodyInertObserver() {
+  if (bodyInertObserver || typeof MutationObserver === 'undefined' || !document.body) {
+    return;
+  }
+
+  bodyInertObserver = new MutationObserver((mutations) => {
+    if (openModalStack.length === 0) return;
+    for (const mutation of mutations) {
+      if (mutation.addedNodes.length > 0) {
+        syncModalBackgroundInert();
+        return;
+      }
+    }
+  });
+  bodyInertObserver.observe(document.body, { childList: true });
+}
+
+function disconnectBodyInertObserver() {
+  if (!bodyInertObserver) return;
+  bodyInertObserver.disconnect();
+  bodyInertObserver = null;
+}
+
 function syncModalBackgroundInert() {
   const top = openModalStack[openModalStack.length - 1];
 
   if (!top) {
+    disconnectBodyInertObserver();
     priorInertByElement.forEach((prior, el) => {
       if (el.isConnected) el.inert = prior;
     });
     priorInertByElement.clear();
     return;
   }
+
+  ensureBodyInertObserver();
 
   Array.from(document.body.children).forEach((child) => {
     rememberPriorInert(child);

--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -9,6 +9,8 @@ const openModalStack = [];
 const priorInertByElement = new Map();
 /** Single observer for body children added while any modal is open. */
 let bodyInertObserver = null;
+/** Shared body-scroll lock — styles clear only when the last open modal releases. */
+let bodyScrollLockCount = 0;
 
 function rememberPriorInert(el) {
   if (!priorInertByElement.has(el)) {
@@ -76,6 +78,26 @@ function popOpenModal(modal) {
   syncModalBackgroundInert();
 }
 
+function acquireBodyScrollLock() {
+  bodyScrollLockCount += 1;
+  if (bodyScrollLockCount !== 1) return;
+
+  const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+  document.body.style.overflow = 'hidden';
+  if (scrollbarWidth > 0) {
+    document.body.style.paddingRight = `${scrollbarWidth}px`;
+  }
+}
+
+function releaseBodyScrollLock() {
+  if (bodyScrollLockCount === 0) return;
+  bodyScrollLockCount -= 1;
+  if (bodyScrollLockCount !== 0) return;
+
+  document.body.style.overflow = '';
+  document.body.style.paddingRight = '';
+}
+
 class Modal {
   constructor(options = {}) {
     // Configuration
@@ -95,7 +117,6 @@ class Modal {
     // State
     this.isOpen = false;
     this.previousActiveElement = null;
-    this.bodyScrollLocked = false;
 
     // Create modal structure
     this.init();
@@ -306,7 +327,7 @@ class Modal {
     this.overlay.setAttribute('aria-hidden', 'false');
 
     // Lock body scroll and remove background from the keyboard / AT tree
-    this.lockBodyScroll();
+    acquireBodyScrollLock();
     pushOpenModal(this);
 
     // Focus management
@@ -338,7 +359,7 @@ class Modal {
     this.overlay.setAttribute('aria-hidden', 'true');
 
     // Unlock body scroll and restore background interactivity
-    this.unlockBodyScroll();
+    releaseBodyScrollLock();
     popOpenModal(this);
 
     // Restore focus
@@ -404,25 +425,6 @@ class Modal {
     }
   }
 
-  lockBodyScroll() {
-    if (this.bodyScrollLocked) return;
-    
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-    document.body.style.overflow = 'hidden';
-    if (scrollbarWidth > 0) {
-      document.body.style.paddingRight = `${scrollbarWidth}px`;
-    }
-    this.bodyScrollLocked = true;
-  }
-
-  unlockBodyScroll() {
-    if (!this.bodyScrollLocked) return;
-    
-    document.body.style.overflow = '';
-    document.body.style.paddingRight = '';
-    this.bodyScrollLocked = false;
-  }
-
   updateContent(content) {
     this.setContent(content);
   }
@@ -460,9 +462,9 @@ class Modal {
     // Unlock body scroll / inert if still applied
     if (this.isOpen) {
       this.isOpen = false;
+      releaseBodyScrollLock();
       popOpenModal(this);
     }
-    this.unlockBodyScroll();
 
     // Remove from DOM
     if (this.overlay && this.overlay.parentNode) {


### PR DESCRIPTION
## Summary
Closes #6 (D1 from the ChatCPT WCAG 2.2 AA audit).

Open modals now trap keyboard focus and mark background content `inert`, so Tab can no longer walk the page behind a dialog while `aria-modal="true"` claims it is hidden.

## Changes
The previous `open()` path set `aria-modal`, stored the invoking element, and moved focus to the close button — but nothing constrained Tab afterward. After a handful of stops, focus left the dialog entirely (verified in the consuming app: stop 7 was `#newChatBtn`).

This PR adds:
- A capture-phase Tab / Shift+Tab handler that wraps within the dialog's focusable set
- `inert` on every `document.body` child except the modal overlay while open (cleared on close / destroy)
- A `tabindex="-1"` fallback when focusing the title or an empty dialog

Focus restore to the invoking element on close is unchanged.

**Consumer note:** ChatCPT portals the Thinking dropdown menu to `document.body` (audit finding D7). With background `inert`, that portaled menu is intentionally unreachable until D7 lands — same structural gap the audit already flags for screen readers. Prefer fixing ownership/portaling in the app rather than weakening the trap here.

## Test plan
- [x] Open `components/modal/test.html`, open a modal, Tab repeatedly — focus stays inside and wraps last → first
- [x] Shift+Tab from the first focusable wraps to the last
- [x] Background controls are not reachable by keyboard while open; `document.body` children other than the overlay have `inert`
- [x] Close restores focus to the control that opened the modal
- [x] Escape and overlay-click close still work
- [x] Smoke in ChatCPT settings modal after submodule bump (expect Thinking menu keyboard gap until D7)
