### PR TITLE
fix(a11y): expose dropdown selection via aria-selected (D4)

### DIFF
--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -67,8 +67,7 @@ Select-only combobox pattern (APG):
 - Toggle is a `<button role="combobox">` with `aria-haspopup="listbox"`, `aria-expanded`, and `aria-controls` pointing at the popup.
 - Popup panel is `role="listbox"`; the layout wrapper uses `role="presentation"` so options are owned by the listbox.
 - Options are plain elements with `role="option"` and `tabindex="-1"` (not `<button>`).
-
-Selection state exposure (`aria-selected`) is tracked separately as D4.
+- Every option exposes `aria-selected="true"` or `"false"`; the checkmark SVG is decorative (`aria-hidden`) and is not the only selection cue.
 
 ## API Methods
 
@@ -89,7 +88,7 @@ npx playwright install chromium
 npm test
 ```
 
-`tests/dropdown-focus.spec.js` covers Tab / Shift+Tab open-state behavior against `test.html` in light and dark (`colorScheme`), plus a scoped axe scan (`tests/helpers/a11y.js`).
+`tests/dropdown-focus.spec.js` covers Tab / Shift+Tab open-state behavior against `test.html` in light and dark (`colorScheme`), plus a scoped axe scan (`tests/helpers/a11y.js`). Selection state (`aria-selected`) is covered in the same suite.
 
 ## Dependencies
 

--- a/components/dropdown/dropdown.js
+++ b/components/dropdown/dropdown.js
@@ -131,8 +131,11 @@ class Dropdown {
     menuItem.tabIndex = -1;
     menuItem.setAttribute('data-value', item.value);
     menuItem.setAttribute('data-index', index);
+    // Programmatic selection state for AT (D4); checkmark stays visual-only.
+    const isSelected = this.selectedValue === item.value;
+    menuItem.setAttribute('aria-selected', isSelected ? 'true' : 'false');
 
-    if (this.selectedValue === item.value) {
+    if (isSelected) {
       menuItem.classList.add('selected');
     }
 
@@ -140,8 +143,8 @@ class Dropdown {
     itemContent.className = 'dropdown-menu-item-content';
     itemContent.setAttribute('role', 'presentation');
 
-    // Checkmark icon (only show if selected)
-    if (this.selectedValue === item.value) {
+    // Checkmark icon (only show if selected; decorative — aria-selected is the signal)
+    if (isSelected) {
       const checkmark = document.createElement('span');
       checkmark.className = 'dropdown-menu-item-checkmark';
       checkmark.setAttribute('aria-hidden', 'true');
@@ -554,11 +557,12 @@ class Dropdown {
     this.selectedValue = value;
     this.close();
     
-    // Update menu items
+    // Update menu items (visual selected class + aria-selected for AT)
     const items = this.menuList.querySelectorAll('.dropdown-menu-item');
     items.forEach(item => {
       if (item.getAttribute('data-value') === value) {
         item.classList.add('selected');
+        item.setAttribute('aria-selected', 'true');
         // Add checkmark if not present
         if (!item.querySelector('.dropdown-menu-item-checkmark')) {
           const checkmark = document.createElement('span');
@@ -572,6 +576,7 @@ class Dropdown {
         }
       } else {
         item.classList.remove('selected');
+        item.setAttribute('aria-selected', 'false');
         const checkmark = item.querySelector('.dropdown-menu-item-checkmark');
         if (checkmark) {
           checkmark.remove();

--- a/tests/dropdown-focus.spec.js
+++ b/tests/dropdown-focus.spec.js
@@ -134,4 +134,80 @@ for (const colorScheme of ['light', 'dark']) {
       await expectNoAxeViolations(page, '#dropdown-basic');
     });
   });
+
+  test.describe(`dropdown selection (aria-selected) — ${colorScheme}`, () => {
+    test.use({ colorScheme });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/components/dropdown/test.html');
+      await page.waitForFunction(() => window.testDropdowns?.basic);
+    });
+
+    test('preselected value exposes aria-selected on exactly one option', async ({
+      page,
+    }) => {
+      await page.locator('#dropdown-preselected .dropdown-toggle').focus();
+      await page.keyboard.press('ArrowDown');
+
+      const state = await selectionState(page, '#dropdown-preselected');
+      expect(state.total).toBeGreaterThan(0);
+      expect(state.selectedCount).toBe(1);
+      expect(state.selectedValues).toEqual(['option-2']);
+      expect(state.allHaveAriaSelected).toBe(true);
+      expect(state.falseCount).toBe(state.total - 1);
+
+      await expectNoAxeViolations(page, '#dropdown-preselected');
+    });
+
+    test('selecting an option updates aria-selected on all options', async ({
+      page,
+    }) => {
+      const basic = page.locator('#dropdown-basic');
+      await basic.locator('.dropdown-toggle').focus();
+      await page.keyboard.press('ArrowDown');
+
+      let state = await selectionState(page, '#dropdown-basic');
+      expect(state.selectedCount).toBe(0);
+      expect(state.allHaveAriaSelected).toBe(true);
+      expect(state.falseCount).toBe(state.total);
+
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Enter');
+
+      await expect(basic).not.toHaveClass(/open/);
+      await basic.locator('.dropdown-toggle').focus();
+      await page.keyboard.press('ArrowDown');
+
+      state = await selectionState(page, '#dropdown-basic');
+      expect(state.selectedCount).toBe(1);
+      expect(state.selectedValues).toEqual(['option-2']);
+      expect(state.allHaveAriaSelected).toBe(true);
+      expect(state.falseCount).toBe(state.total - 1);
+
+      await expectNoAxeViolations(page, '#dropdown-basic');
+    });
+  });
+}
+
+/** aria-selected snapshot for options under a dropdown root. */
+function selectionState(page, rootSelector) {
+  return page.evaluate((sel) => {
+    const root = document.querySelector(sel);
+    const options = Array.from(root.querySelectorAll('[role="option"]'));
+    const selected = options.filter(
+      (o) => o.getAttribute('aria-selected') === 'true',
+    );
+    return {
+      total: options.length,
+      selectedCount: selected.length,
+      selectedValues: selected.map((o) => o.getAttribute('data-value')),
+      falseCount: options.filter(
+        (o) => o.getAttribute('aria-selected') === 'false',
+      ).length,
+      allHaveAriaSelected: options.every((o) => {
+        const v = o.getAttribute('aria-selected');
+        return v === 'true' || v === 'false';
+      }),
+    };
+  }, rootSelector);
 }


### PR DESCRIPTION
## Summary
Closes #9 ([a11y][D4]). Dropdown options now expose selection programmatically with `aria-selected`, so the active choice is not conveyed by color/checkmark alone.

## Changes
In `components/dropdown/`:
- `createMenuItem`: every `role="option"` gets `aria-selected="true"|"false"` from the initial `selectedValue`
- `selectItem`: updates `aria-selected` alongside the `.selected` class and checkmark
- Checkmark remains decorative (`aria-hidden`); D2/D3 focus and combobox/listbox behavior unchanged

## Test plan
- [x] `npm test` — Playwright light + dark: preselected dropdown has exactly one `aria-selected="true"`; after select, selected option is `"true"` and others `"false"`; scoped axe clean
- [x] Existing Tab / Shift+Tab focus suite still green
- [ ] Optional: VoiceOver / accessibility tree confirms selected option announced


Made with [Cursor](https://cursor.com)