### PR TITLE
fix(a11y): put role=slider on handles, not the wrapper (D5)

### DIFF
--- a/components/numeric-slider/README.md
+++ b/components/numeric-slider/README.md
@@ -267,6 +267,18 @@ const heavySlider = new NumericSlider('#heavy-slider', {
 - Invalid input (non-numeric) is reset to the current value on blur
 - Input fields use the same styling as the input component
 
+## Tests
+
+From the design-system repo root:
+
+```bash
+npm ci
+npx playwright install chromium
+npm test
+```
+
+`tests/numeric-slider-a11y.spec.js` covers slider role placement, single-number `aria-valuenow` (including range), disabled state, keyboard stepping, and scoped axe scans in light and dark (`colorScheme`).
+
 ## Dependencies
 
 This component relies on variables from:
@@ -286,16 +298,11 @@ The slider automatically validates and corrects values:
 
 ## Accessibility
 
-The slider component includes comprehensive accessibility features:
-
-- **ARIA Attributes**:
-  - `role="slider"` on the slider wrapper
-  - `aria-valuemin`, `aria-valuemax`, `aria-valuenow` attributes
-  - `aria-label` attributes on handles and wrapper for screen readers
-- **Keyboard Navigation**: Full keyboard support with arrow keys, Home, End, and Shift modifiers
-- **Focus Indicators**: Visible focus outlines for keyboard navigation
-- **Input Fields**: Proper `id` and `name` attributes for form integration and screen readers
-- **Disabled State**: Properly communicates disabled state to assistive technologies
+- Each handle is the slider: `role="slider"` with `aria-valuemin` / `aria-valuemax` / `aria-valuenow` (always a single number), `aria-valuetext`, `aria-orientation="horizontal"`, and `aria-label`.
+- The `.numeric-slider-wrapper` is presentational only (no role, no tabindex) so there is one tab stop per handle and no nested interactive.
+- Range mode: each thumb exposes its own `aria-valuenow`; values are never comma-joined.
+- Disabled: handles use `aria-disabled="true"` and `tabindex="-1"` (plus the native `disabled` attribute).
+- Keyboard: Arrow Left/Down, Arrow Right/Up, Shift+Arrow (10× step), Home, End.
 
 ## Error Handling
 

--- a/components/numeric-slider/numeric-slider.js
+++ b/components/numeric-slider/numeric-slider.js
@@ -138,21 +138,9 @@ class NumericSlider {
       }
     }
 
-    // Create slider wrapper
+    // Presentational wrapper — each handle is the slider (D5 / nested-interactive).
     this.wrapper = document.createElement('div');
     this.wrapper.className = 'numeric-slider-wrapper';
-    this.wrapper.setAttribute('role', 'slider');
-    this.wrapper.setAttribute('aria-valuemin', this.config.min);
-    this.wrapper.setAttribute('aria-valuemax', this.config.max);
-    this.wrapper.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
-
-    if (this.config.type === 'range') {
-      this.wrapper.setAttribute('aria-valuenow', `${this.values[0]},${this.values[1]}`);
-      this.wrapper.setAttribute('aria-label', `Range slider from ${this.values[0]} to ${this.values[1]}`);
-    } else {
-      this.wrapper.setAttribute('aria-valuenow', this.values);
-      this.wrapper.setAttribute('aria-label', `Slider value ${this.values}`);
-    }
 
     // Create track
     this.track = document.createElement('div');
@@ -168,7 +156,7 @@ class NumericSlider {
       this.filled.classList.add('theme-primary');
     }
 
-    // Create handles
+    // Create handles (role=slider + value attrs live here, not on the wrapper)
     if (this.config.type === 'range') {
       // Min handle
       this.minHandle = document.createElement('button');
@@ -177,9 +165,10 @@ class NumericSlider {
         this.minHandle.classList.add('theme-primary');
       }
       this.minHandle.setAttribute('type', 'button');
-      this.minHandle.setAttribute('aria-label', `Minimum value: ${this.values[0]}`);
-      this.minHandle.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
-      this.minHandle.disabled = this.config.disabled;
+      this.applyHandleSliderRole(this.minHandle, {
+        value: this.values[0],
+        label: 'Minimum value',
+      });
 
       // Max handle
       this.maxHandle = document.createElement('button');
@@ -188,9 +177,10 @@ class NumericSlider {
         this.maxHandle.classList.add('theme-primary');
       }
       this.maxHandle.setAttribute('type', 'button');
-      this.maxHandle.setAttribute('aria-label', `Maximum value: ${this.values[1]}`);
-      this.maxHandle.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
-      this.maxHandle.disabled = this.config.disabled;
+      this.applyHandleSliderRole(this.maxHandle, {
+        value: this.values[1],
+        label: 'Maximum value',
+      });
 
       this.track.appendChild(this.filled);
       this.track.appendChild(this.minHandle);
@@ -203,9 +193,10 @@ class NumericSlider {
         this.handle.classList.add('theme-primary');
       }
       this.handle.setAttribute('type', 'button');
-      this.handle.setAttribute('aria-label', `Value: ${this.values}`);
-      this.handle.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
-      this.handle.disabled = this.config.disabled;
+      this.applyHandleSliderRole(this.handle, {
+        value: this.values,
+        label: 'Value',
+      });
 
       this.track.appendChild(this.filled);
       this.track.appendChild(this.handle);
@@ -275,8 +266,7 @@ class NumericSlider {
       }
     }
 
-    // Keyboard navigation
-    this.wrapper.addEventListener('keydown', (e) => this.handleKeyDown(e));
+    // Keyboard navigation on handles (wrapper is not focusable)
     if (this.config.type === 'range') {
       this.minHandle.addEventListener('keydown', (e) => this.handleKeyDown(e, 'min'));
       this.maxHandle.addEventListener('keydown', (e) => this.handleKeyDown(e, 'max'));
@@ -494,6 +484,37 @@ class NumericSlider {
     return Math.round((value - this.config.min) / this.config.step) * this.config.step + this.config.min;
   }
 
+  /**
+   * Expose one handle as a slider with a single-number value (D5).
+   * @param {HTMLElement} handle
+   * @param {{ value: number, label: string }} opts
+   */
+  applyHandleSliderRole(handle, { value, label }) {
+    handle.setAttribute('role', 'slider');
+    handle.setAttribute('aria-orientation', 'horizontal');
+    handle.setAttribute('aria-valuemin', String(this.config.min));
+    handle.setAttribute('aria-valuemax', String(this.config.max));
+    handle.setAttribute('aria-valuenow', String(value));
+    handle.setAttribute('aria-valuetext', String(value));
+    handle.setAttribute('aria-label', label);
+    handle.setAttribute('tabindex', this.config.disabled ? '-1' : '0');
+    handle.setAttribute('aria-disabled', this.config.disabled ? 'true' : 'false');
+    handle.disabled = this.config.disabled;
+  }
+
+  /** Sync aria-valuenow / aria-valuetext on every handle after value changes. */
+  updateHandleAria() {
+    if (this.config.type === 'range') {
+      this.minHandle.setAttribute('aria-valuenow', String(this.values[0]));
+      this.minHandle.setAttribute('aria-valuetext', String(this.values[0]));
+      this.maxHandle.setAttribute('aria-valuenow', String(this.values[1]));
+      this.maxHandle.setAttribute('aria-valuetext', String(this.values[1]));
+    } else {
+      this.handle.setAttribute('aria-valuenow', String(this.values));
+      this.handle.setAttribute('aria-valuetext', String(this.values));
+    }
+  }
+
   updateVisuals() {
     const range = this.config.max - this.config.min;
 
@@ -515,11 +536,7 @@ class NumericSlider {
         this.maxInput.value = Math.round(this.values[1]);
       }
 
-      // Update aria attributes
-      this.wrapper.setAttribute('aria-valuenow', `${this.values[0]},${this.values[1]}`);
-      this.wrapper.setAttribute('aria-label', `Range slider from ${this.values[0]} to ${this.values[1]}`);
-      this.minHandle.setAttribute('aria-label', `Minimum value: ${this.values[0]}`);
-      this.maxHandle.setAttribute('aria-label', `Maximum value: ${this.values[1]}`);
+      this.updateHandleAria();
     } else {
       const percent = ((this.values - this.config.min) / range) * 100;
 
@@ -535,10 +552,7 @@ class NumericSlider {
         this.valueInput.value = Math.round(this.values);
       }
 
-      // Update aria attributes
-      this.wrapper.setAttribute('aria-valuenow', this.values);
-      this.wrapper.setAttribute('aria-label', `Slider value ${this.values}`);
-      this.handle.setAttribute('aria-label', `Value: ${this.values}`);
+      this.updateHandleAria();
     }
   }
 
@@ -577,25 +591,26 @@ class NumericSlider {
   setDisabled(disabled) {
     this.config.disabled = disabled;
 
+    const syncHandleDisabled = (handle) => {
+      if (!handle) return;
+      handle.setAttribute('tabindex', disabled ? '-1' : '0');
+      handle.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+      handle.disabled = disabled;
+    };
+
     if (disabled) {
       this.container.classList.add('disabled');
-      this.wrapper.setAttribute('tabindex', '-1');
-      if (this.minHandle) this.minHandle.setAttribute('tabindex', '-1');
-      if (this.maxHandle) this.maxHandle.setAttribute('tabindex', '-1');
-      if (this.handle) this.handle.setAttribute('tabindex', '-1');
-      if (this.minInput) this.minInput.disabled = true;
-      if (this.maxInput) this.maxInput.disabled = true;
-      if (this.valueInput) this.valueInput.disabled = true;
     } else {
       this.container.classList.remove('disabled');
-      this.wrapper.setAttribute('tabindex', '0');
-      if (this.minHandle) this.minHandle.setAttribute('tabindex', '0');
-      if (this.maxHandle) this.maxHandle.setAttribute('tabindex', '0');
-      if (this.handle) this.handle.setAttribute('tabindex', '0');
-      if (this.minInput) this.minInput.disabled = false;
-      if (this.maxInput) this.maxInput.disabled = false;
-      if (this.valueInput) this.valueInput.disabled = false;
     }
+
+    syncHandleDisabled(this.minHandle);
+    syncHandleDisabled(this.maxHandle);
+    syncHandleDisabled(this.handle);
+
+    if (this.minInput) this.minInput.disabled = disabled;
+    if (this.maxInput) this.maxInput.disabled = disabled;
+    if (this.valueInput) this.valueInput.disabled = disabled;
   }
 
   destroy() {

--- a/components/numeric-slider/test.html
+++ b/components/numeric-slider/test.html
@@ -390,21 +390,21 @@
     });
 
     // Disabled sliders
-    new NumericSlider('#slider-disabled-single', {
+    const sliderDisabledSingle = new NumericSlider('#slider-disabled-single', {
       type: 'single',
       value: 50,
       showInputs: true,
       disabled: true
     });
 
-    new NumericSlider('#slider-disabled-range', {
+    const sliderDisabledRange = new NumericSlider('#slider-disabled-range', {
       type: 'range',
       value: [20, 60],
       showInputs: true,
       disabled: true
     });
 
-    // Make sliders available globally for debugging
+    // Make sliders available globally for debugging / Playwright
     window.testSliders = {
       singleDefault: sliderSingleDefault,
       singleInput: sliderSingleInput,
@@ -416,7 +416,9 @@
       negativeRange: sliderNegativeRange,
       presetSingle: sliderPresetSingle,
       presetRange: sliderPresetRange,
-      continuous: sliderContinuous
+      continuous: sliderContinuous,
+      disabledSingle: sliderDisabledSingle,
+      disabledRange: sliderDisabledRange
     };
   </script>
 </body>

--- a/tests/numeric-slider-a11y.spec.js
+++ b/tests/numeric-slider-a11y.spec.js
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+import { expectNoAxeViolations } from './helpers/a11y.js';
+
+/**
+ * D5: role=slider and value attrs live on each handle; wrapper is not
+ * interactive; aria-valuenow is always a single number (range included).
+ *
+ * Themes use Playwright `colorScheme`, which drives the design-system
+ * `@media (prefers-color-scheme: dark)` tokens.
+ */
+
+function sliderAriaState(page, rootSelector) {
+  return page.evaluate((sel) => {
+    const root = document.querySelector(sel);
+    const wrapper = root.querySelector('.numeric-slider-wrapper');
+    const handles = Array.from(root.querySelectorAll('.numeric-slider-handle'));
+    return {
+      wrapperRole: wrapper?.getAttribute('role'),
+      wrapperTabindex: wrapper?.getAttribute('tabindex'),
+      handleCount: handles.length,
+      handles: handles.map((h) => ({
+        role: h.getAttribute('role'),
+        tabindex: h.getAttribute('tabindex'),
+        valuemin: h.getAttribute('aria-valuemin'),
+        valuemax: h.getAttribute('aria-valuemax'),
+        valuenow: h.getAttribute('aria-valuenow'),
+        valuetext: h.getAttribute('aria-valuetext'),
+        orientation: h.getAttribute('aria-orientation'),
+        ariaDisabled: h.getAttribute('aria-disabled'),
+        disabled: h.disabled,
+        label: h.getAttribute('aria-label'),
+      })),
+    };
+  }, rootSelector);
+}
+
+for (const colorScheme of ['light', 'dark']) {
+  test.describe(`numeric slider a11y — ${colorScheme}`, () => {
+    test.use({ colorScheme });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/components/numeric-slider/test.html');
+      await page.waitForFunction(() => window.testSliders?.singleDefault);
+    });
+
+    test('single slider: handle is the slider; wrapper is not focusable', async ({
+      page,
+    }) => {
+      const state = await sliderAriaState(page, '#slider-single-default');
+
+      expect(state.wrapperRole).toBeNull();
+      expect(state.wrapperTabindex).toBeNull();
+      expect(state.handleCount).toBe(1);
+
+      const [handle] = state.handles;
+      expect(handle.role).toBe('slider');
+      expect(handle.tabindex).toBe('0');
+      expect(handle.orientation).toBe('horizontal');
+      expect(handle.valuemin).toBe('0');
+      expect(handle.valuemax).toBe('100');
+      expect(handle.valuenow).toBe('50');
+      expect(handle.valuetext).toBe('50');
+      expect(handle.ariaDisabled).toBe('false');
+      expect(Number.isNaN(Number(handle.valuenow))).toBe(false);
+
+      await expectNoAxeViolations(page, '#slider-single-default');
+    });
+
+    test('range slider: each handle has its own single-number aria-valuenow', async ({
+      page,
+    }) => {
+      const state = await sliderAriaState(page, '#slider-range-default');
+
+      expect(state.wrapperRole).toBeNull();
+      expect(state.wrapperTabindex).toBeNull();
+      expect(state.handleCount).toBe(2);
+
+      const [minHandle, maxHandle] = state.handles;
+      expect(minHandle.role).toBe('slider');
+      expect(maxHandle.role).toBe('slider');
+      expect(minHandle.valuenow).toBe('20');
+      expect(maxHandle.valuenow).toBe('60');
+      expect(minHandle.valuenow.includes(',')).toBe(false);
+      expect(maxHandle.valuenow.includes(',')).toBe(false);
+      expect(minHandle.label).toBe('Minimum value');
+      expect(maxHandle.label).toBe('Maximum value');
+
+      await expectNoAxeViolations(page, '#slider-range-default');
+    });
+
+    test('disabled slider exposes aria-disabled and is not tabbable', async ({
+      page,
+    }) => {
+      const state = await sliderAriaState(page, '#slider-disabled-single');
+      const [handle] = state.handles;
+
+      expect(handle.tabindex).toBe('-1');
+      expect(handle.ariaDisabled).toBe('true');
+      expect(handle.disabled).toBe(true);
+
+      // Scope to the track/handles — companion number inputs are unlabeled in
+      // the fixture (app labeling is D6 / aria-labelledby), not part of D5.
+      await expectNoAxeViolations(
+        page,
+        '#slider-disabled-single .numeric-slider-wrapper',
+      );
+    });
+
+    test('keyboard arrows update aria-valuenow on the focused handle', async ({
+      page,
+    }) => {
+      const handle = page.locator(
+        '#slider-single-default .numeric-slider-handle',
+      );
+      await handle.focus();
+      await page.keyboard.press('ArrowRight');
+
+      await expect(handle).toHaveAttribute('aria-valuenow', '51');
+      await expect(handle).toHaveAttribute('aria-valuetext', '51');
+
+      await page.keyboard.press('Home');
+      await expect(handle).toHaveAttribute('aria-valuenow', '0');
+
+      await page.keyboard.press('End');
+      await expect(handle).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes #10 ([a11y][D5]). Each slider handle is now the `role="slider"` control; the wrapper is presentational only. Range mode exposes a single-number `aria-valuenow` per thumb.

## Changes
In `components/numeric-slider/`:
- Wrapper: no `role`, no `tabindex`, no value attributes
- Handles: `role="slider"`, `aria-valuemin`/`max`/`now`/`valuetext`, `aria-orientation="horizontal"`, `aria-label`
- Disabled: `aria-disabled="true"` + `tabindex="-1"` (alongside native `disabled`)
- Keyboard still on handles (arrows, Shift, Home, End); wrapper keydown listener removed

**Note for consumers:** DOM/ARIA for the slider changed (value attrs moved from `.numeric-slider-wrapper` onto `.numeric-slider-handle`). Selectors that read wrapper aria attributes will need updating.

## Test plan
- [x] `npm test` — Playwright light + dark: single/range role placement, single-number `aria-valuenow`, disabled attrs, keyboard updates, scoped axe (no `nested-interactive`)
- [x] Existing dropdown suite still green
- [ ] Optional: settings modal in ChatCPT after submodule bump (not in this PR)


Made with [Cursor](https://cursor.com)