### PR TITLE
fix(a11y): raise dark primary and body text contrast tokens (A7, A8)

### DIFF
--- a/colors/README.md
+++ b/colors/README.md
@@ -64,3 +64,15 @@ Categories:
 
 The system automatically handles Dark Mode via the `@media (prefers-color-scheme: dark)` query. By using the **Semantic Names**, your components will automatically adapt to the user's system preference.
 
+## Contrast (WCAG)
+
+Semantic text and focus tokens are chosen to meet WCAG 2.2 AA against `Backgrounds-Main-Top` in each theme:
+
+| Token | Requirement | Notes |
+| :--- | :--- | :--- |
+| `--Colors-Primary-Default` | ≥ 3:1 (non-text / focus) | Dark mode uses a lighter primary step so focus rings clear the threshold. |
+| `--Colors-Text-Body-Lighter` | ≥ 4.5:1 (body text) | Use at full opacity. **Do not fade this token** with `opacity` — layering transparency will drop it below 4.5:1. |
+| `--Colors-Text-Body-Light` | ≥ 4.5:1 | Also used for input placeholders; kept one step stronger than Lighter. |
+
+`npm test` includes `tests/contrast-tokens.spec.js`, which measures these ratios in light and dark.
+

--- a/colors/colors.css
+++ b/colors/colors.css
@@ -215,8 +215,11 @@
   --Colors-Text-Body-White: var(--Colors-Base-Neutral-00);
   --Colors-Text-Body-Default: var(--Colors-Base-Neutral-1200);
   --Colors-Text-Body-Medium: var(--Colors-Base-Neutral-1050);
-  --Colors-Text-Body-Light: var(--Colors-Base-Neutral-900);
-  --Colors-Text-Body-Lighter: var(--Colors-Base-Neutral-800);
+  /* Light/Lighter darkened for WCAG 1.4.3 (A8). Lighter clears 4.5:1 on
+     Backgrounds-Main-Top; Light stays one step stronger for hierarchy and
+     input placeholders. Do not fade these tokens with opacity. */
+  --Colors-Text-Body-Light: var(--Colors-Base-Neutral-1000);
+  --Colors-Text-Body-Lighter: var(--Colors-Base-Neutral-950);
   --Colors-Text-Body-Strong: var(--Colors-Base-Neutral-1350);
   --Colors-Text-Body-Strongest: var(--Colors-Base-Neutral-1450); 
 
@@ -276,7 +279,8 @@
 @media (prefers-color-scheme: dark) {
   :root {
     /* Primary Colors - Semantic Names (ElevatedDark Mode) */
-    --Colors-Primary-Default: var(--Colors-Base-Primary-700);
+    /* Lightened so focus rings / Primary-Default meet 3:1 on dark surfaces (A7). */
+    --Colors-Primary-Default: var(--Colors-Base-Primary-450);
     --Colors-Primary-Lightest: var(--Colors-Base-Primary-400);   
     --Colors-Primary-Lighter: var(--Colors-Base-Primary-450);    
     --Colors-Primary-Light: var(--Colors-Base-Primary-450);      
@@ -300,8 +304,9 @@
     /* Text Colors - Semantic Names (Elevated Dark Mode) */
     --Colors-Text-Body-Default: var(--Colors-Base-Neutral-450);
     --Colors-Text-Body-Medium: var(--Colors-Base-Neutral-650);
-    --Colors-Text-Body-Light: var(--Colors-Base-Neutral-750);
-    --Colors-Text-Body-Lighter: var(--Colors-Base-Neutral-900);
+    /* Light/Lighter raised for WCAG 1.4.3 (A8); Light stays stronger than Lighter. */
+    --Colors-Text-Body-Light: var(--Colors-Base-Neutral-650);
+    --Colors-Text-Body-Lighter: var(--Colors-Base-Neutral-700);
     --Colors-Text-Body-Strong: var(--Colors-Base-Neutral-00);
     --Colors-Text-Body-Strongest: var(--Colors-Base-Neutral-00);
     

--- a/components/button/button.css
+++ b/components/button/button.css
@@ -45,12 +45,13 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --Colors-Buttons-Secondary-Default: var(--Colors-Base-Primary-600);
-        --Colors-Buttons-Secondary-Default-Text: var(--Colors-Base-Primary-600);
-        --Colors-Buttons-Secondary-Hover: var(--Colors-Base-Primary-500);
-        --Colors-Buttons-Secondary-Hover-Text: var(--Colors-Base-Primary-500);
-        --Colors-Buttons-Secondary-Pressed: var(--Colors-Base-Primary-650);
-        --Colors-Buttons-Secondary-Pressed-Text: var(--Colors-Base-Primary-650);
+        /* Secondary label/border lightened for 4.5:1 on dark surfaces (A8). */
+        --Colors-Buttons-Secondary-Default: var(--Colors-Base-Primary-450);
+        --Colors-Buttons-Secondary-Default-Text: var(--Colors-Base-Primary-450);
+        --Colors-Buttons-Secondary-Hover: var(--Colors-Base-Primary-400);
+        --Colors-Buttons-Secondary-Hover-Text: var(--Colors-Base-Primary-400);
+        --Colors-Buttons-Secondary-Pressed: var(--Colors-Base-Primary-500);
+        --Colors-Buttons-Secondary-Pressed-Text: var(--Colors-Base-Primary-500);
         --Colors-Buttons-Tertiary-Default-Background: var(--Colors-Base-Neutral-Alphas-1200-25);
         --Colors-Buttons-Tertiary-Default-Text: var(--Colors-Base-Neutral-500);
         --Colors-Buttons-Tertiary-Hover: var(--Colors-Base-Neutral-1100);

--- a/tests/contrast-tokens.spec.js
+++ b/tests/contrast-tokens.spec.js
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * A7 / A8 — measure semantic token contrast against Backgrounds-Main-Top
+ * (and secondary button text on the same surface) in light and dark.
+ */
+
+function contrastRatio(fgHex, bgHex) {
+  const rel = (hex) => {
+    const h = hex.replace('#', '');
+    const rgb = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255);
+    const f = (c) =>
+      c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
+  };
+  const L1 = rel(fgHex);
+  const L2 = rel(bgHex);
+  return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+}
+
+async function readTokens(page) {
+  return page.evaluate(() => {
+    const toHex = (rgb) => {
+      const m = String(rgb).match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+      if (!m) return String(rgb);
+      return (
+        '#' +
+        [m[1], m[2], m[3]]
+          .map((n) => Number(n).toString(16).padStart(2, '0'))
+          .join('')
+      );
+    };
+
+    const probe = document.getElementById('probe');
+    const sample = (cssColor) => {
+      probe.style.color = cssColor;
+      void probe.offsetHeight;
+      return toHex(getComputedStyle(probe).color);
+    };
+    const sampleBg = (cssBg) => {
+      probe.style.backgroundColor = cssBg;
+      void probe.offsetHeight;
+      return toHex(getComputedStyle(probe).backgroundColor);
+    };
+
+    return {
+      bg: sampleBg('var(--Colors-Backgrounds-Main-Top)'),
+      primaryDefault: sample('var(--Colors-Primary-Default)'),
+      bodyLighter: sample('var(--Colors-Text-Body-Lighter)'),
+      bodyLight: sample('var(--Colors-Text-Body-Light)'),
+      secondaryText: sample('var(--Colors-Buttons-Secondary-Default-Text)'),
+    };
+  });
+}
+
+for (const colorScheme of ['light', 'dark']) {
+  test.describe(`contrast tokens — ${colorScheme}`, () => {
+    test.use({ colorScheme });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/tests/fixtures/contrast-tokens.html');
+      await page.waitForFunction(() =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue('--Colors-Primary-Default')
+          .trim(),
+      );
+    });
+
+    test('Primary-Default focus-ring color meets 3:1 on Main-Top', async ({
+      page,
+    }) => {
+      const t = await readTokens(page);
+      const ratio = contrastRatio(t.primaryDefault, t.bg);
+      expect(
+        ratio,
+        `${t.primaryDefault} on ${t.bg} = ${ratio.toFixed(2)}:1`,
+      ).toBeGreaterThanOrEqual(3);
+    });
+
+    test('Text-Body-Lighter meets 4.5:1 on Main-Top', async ({ page }) => {
+      const t = await readTokens(page);
+      const ratio = contrastRatio(t.bodyLighter, t.bg);
+      expect(
+        ratio,
+        `${t.bodyLighter} on ${t.bg} = ${ratio.toFixed(2)}:1`,
+      ).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test('Text-Body-Light meets 4.5:1 and stays stronger than Lighter', async ({
+      page,
+    }) => {
+      const t = await readTokens(page);
+      const light = contrastRatio(t.bodyLight, t.bg);
+      const lighter = contrastRatio(t.bodyLighter, t.bg);
+      expect(
+        light,
+        `${t.bodyLight} on ${t.bg} = ${light.toFixed(2)}:1`,
+      ).toBeGreaterThanOrEqual(4.5);
+      expect(light).toBeGreaterThanOrEqual(lighter);
+    });
+
+    test('button-secondary text meets 4.5:1 on Main-Top', async ({ page }) => {
+      const t = await readTokens(page);
+      const ratio = contrastRatio(t.secondaryText, t.bg);
+      expect(
+        ratio,
+        `${t.secondaryText} on ${t.bg} = ${ratio.toFixed(2)}:1`,
+      ).toBeGreaterThanOrEqual(4.5);
+    });
+  });
+}

--- a/tests/fixtures/contrast-tokens.html
+++ b/tests/fixtures/contrast-tokens.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Contrast token fixture</title>
+  <link rel="stylesheet" href="/colors/colors.css" />
+  <link rel="stylesheet" href="/components/button/button.css" />
+</head>
+<body>
+  <p id="probe">probe</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Closes #11 ([a11y][A7]) and #12 ([a11y][A8]). Shared semantic tokens now meet WCAG AA contrast against `Backgrounds-Main-Top` in both themes. **Visual change for all DS consumers** — please confirm with design-system owners before merge.

## Token changes
| Token | Light | Dark |
|---|---|---|
| `--Colors-Primary-Default` (A7) | unchanged `Primary-700` (5.05:1) | `Primary-700` → **`Primary-450`** (~5.5:1 vs `#1D2740`) |
| `--Colors-Text-Body-Lighter` (A8) | `Neutral-800` → **`Neutral-950`** (~5.7:1) | `Neutral-900` → **`Neutral-700`** (~5.6:1) |
| `--Colors-Text-Body-Light` | `Neutral-900` → **`Neutral-1000`** (keeps Light ≥ Lighter; fixes placeholders) | `Neutral-750` → **`Neutral-650`** |
| `--Colors-Buttons-Secondary-*` (dark) | — | Default/Text → **`Primary-450`**; Hover → `Primary-400`; Pressed → `Primary-500` |

Primary filled buttons still use `--Colors-Buttons-Primary-*` (`Primary-700`) and are unchanged.

## Notes for consumers
- **Do not fade `--Colors-Text-Body-Lighter` with `opacity`.** Documented in `colors/README.md`. ChatCPT’s `.composer__hint { opacity: 0.8 }` will still fail in light until that opacity is removed (handle in the submodule bump PR).
- No `learn_cosmo-chat` submodule bump in this PR.

## Test plan
- [x] `npm test` — `tests/contrast-tokens.spec.js` measures Primary-Default ≥ 3:1 and body/secondary text ≥ 4.5:1 in light + dark; existing dropdown/slider suites green
- [ ] Design-system owner visual review (shared token impact)
- [ ] After submodule bump: re-measure ChatCPT sidebar labels, placeholders, secondary button; drop composer hint opacity if still failing


Made with [Cursor](https://cursor.com)