### PR TITLE
fix(a11y): unique modal title ids and close-time listener cleanup

### DIFF
--- a/components/modal/README.md
+++ b/components/modal/README.md
@@ -401,10 +401,11 @@ Footer buttons support the following types:
 
 The modal component includes:
 
-- **ARIA Attributes**: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
+- **ARIA Attributes**: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing at a unique `modal-title-${n}` per instance
 - **Focus Management**: Focuses the close button (or title / dialog) on open, and restores focus to the invoking element on close
-- **Keyboard Navigation**: Escape key closes modal
+- **Keyboard Navigation**: Escape key closes the topmost open modal. Document-level keydown listeners attach on `open()` and detach on `close()`, so retained overlays do not accumulate global handlers
 - **Focus Trap**: Tab and Shift+Tab cycle only among focusable elements inside the dialog; background siblings are marked `inert` while open
+- **Reduced motion**: In-content hash links use `scrollIntoView({ behavior: 'auto' })` when `prefers-reduced-motion: reduce`
 - **Body Scroll Lock**: Prevents background scrolling when modal is open
 
 ## Dependencies

--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -11,6 +11,14 @@ const priorInertByElement = new Map();
 let bodyInertObserver = null;
 /** Shared body-scroll lock — styles clear only when the last open modal releases. */
 let bodyScrollLockCount = 0;
+/** Per-instance title ids so stacked / retained overlays never share `modal-title`. */
+let modalTitleIdCounter = 0;
+
+function prefersReducedMotion() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
 function rememberPriorInert(el) {
   if (!priorInertByElement.has(el)) {
@@ -117,6 +125,10 @@ class Modal {
     // State
     this.isOpen = false;
     this.previousActiveElement = null;
+    this.documentListenersBound = false;
+
+    modalTitleIdCounter += 1;
+    this.titleId = `modal-title-${modalTitleIdCounter}`;
 
     // Create modal structure
     this.init();
@@ -128,7 +140,9 @@ class Modal {
     this.overlay.className = 'modal-overlay';
     this.overlay.setAttribute('role', 'dialog');
     this.overlay.setAttribute('aria-modal', 'true');
-    this.overlay.setAttribute('aria-labelledby', 'modal-title');
+    if (this.config.title) {
+      this.overlay.setAttribute('aria-labelledby', this.titleId);
+    }
 
     // Create dialog
     this.dialog = document.createElement('div');
@@ -141,7 +155,7 @@ class Modal {
     if (this.config.title) {
       this.title = document.createElement('h2');
       this.title.className = 'modal-title';
-      this.title.id = 'modal-title';
+      this.title.id = this.titleId;
       this.title.textContent = this.config.title;
       this.header.appendChild(this.title);
     }
@@ -283,19 +297,9 @@ class Modal {
       });
     }
 
-    // Escape key
-    if (this.config.closeOnEscape) {
-      this.escapeHandler = (e) => {
-        if (e.key === 'Escape' && this.isOpen) {
-          this.close();
-        }
-      };
-      document.addEventListener('keydown', this.escapeHandler);
-    }
-
-    // Focus trap — keep Tab / Shift+Tab cycling inside the dialog
-    this.focusTrapHandler = (e) => this.handleFocusTrapKeydown(e);
-    document.addEventListener('keydown', this.focusTrapHandler, true);
+    // Document-level Escape / focus-trap listeners attach in open() and
+    // detach in close(), so closed-but-retained overlays do not accumulate
+    // global keydown handlers (D10).
 
     // Prevent dialog clicks from closing modal
     this.dialog.addEventListener('click', (e) => {
@@ -310,7 +314,10 @@ class Modal {
         const targetId = link.hash.substring(1);
         const targetElement = this.content.querySelector(`#${targetId}`);
         if (targetElement) {
-          targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          targetElement.scrollIntoView({
+            behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+            block: 'start',
+          });
         }
       }
     });
@@ -329,6 +336,7 @@ class Modal {
     // Lock body scroll and remove background from the keyboard / AT tree
     acquireBodyScrollLock();
     pushOpenModal(this);
+    this.bindDocumentListeners();
 
     // Focus management
     if (this.closeButton) {
@@ -353,6 +361,7 @@ class Modal {
     if (!this.isOpen) return;
 
     this.isOpen = false;
+    this.unbindDocumentListeners();
 
     // Hide overlay
     this.overlay.classList.remove('open');
@@ -392,6 +401,39 @@ class Modal {
       if (el.closest('[inert]')) return false;
       return el.getClientRects().length > 0;
     });
+  }
+
+  bindDocumentListeners() {
+    if (this.documentListenersBound) return;
+
+    if (this.config.closeOnEscape) {
+      if (!this.escapeHandler) {
+        this.escapeHandler = (e) => {
+          if (e.key !== 'Escape' || !this.isOpen) return;
+          // Only the topmost open modal should close (stacked settings + confirm).
+          if (openModalStack[openModalStack.length - 1] !== this) return;
+          this.close();
+        };
+      }
+      document.addEventListener('keydown', this.escapeHandler);
+    }
+
+    if (!this.focusTrapHandler) {
+      this.focusTrapHandler = (e) => this.handleFocusTrapKeydown(e);
+    }
+    document.addEventListener('keydown', this.focusTrapHandler, true);
+    this.documentListenersBound = true;
+  }
+
+  unbindDocumentListeners() {
+    if (!this.documentListenersBound) return;
+    if (this.escapeHandler) {
+      document.removeEventListener('keydown', this.escapeHandler);
+    }
+    if (this.focusTrapHandler) {
+      document.removeEventListener('keydown', this.focusTrapHandler, true);
+    }
+    this.documentListenersBound = false;
   }
 
   handleFocusTrapKeydown(e) {
@@ -436,8 +478,9 @@ class Modal {
       // Create title if it doesn't exist
       this.title = document.createElement('h2');
       this.title.className = 'modal-title';
-      this.title.id = 'modal-title';
+      this.title.id = this.titleId;
       this.title.textContent = title;
+      this.overlay.setAttribute('aria-labelledby', this.titleId);
       this.header.insertBefore(this.title, this.closeButton || null);
     }
   }
@@ -451,13 +494,7 @@ class Modal {
   }
 
   destroy() {
-    // Remove event listeners
-    if (this.escapeHandler) {
-      document.removeEventListener('keydown', this.escapeHandler);
-    }
-    if (this.focusTrapHandler) {
-      document.removeEventListener('keydown', this.focusTrapHandler, true);
-    }
+    this.unbindDocumentListeners();
 
     // Unlock body scroll / inert if still applied
     if (this.isOpen) {

--- a/tests/modal-a11y.spec.js
+++ b/tests/modal-a11y.spec.js
@@ -1,0 +1,233 @@
+import { test, expect } from '@playwright/test';
+import { expectNoAxeViolations } from './helpers/a11y.js';
+
+/**
+ * D8: unique `modal-title-${n}` per instance, wired through aria-labelledby.
+ * D10: document keydown listeners attach on open and detach on close; Escape
+ *      closes only the topmost stacked modal.
+ * D11: in-modal hash links honor prefers-reduced-motion.
+ */
+
+async function createModal(page, options) {
+  return page.evaluate((opts) => {
+    const modal = new window.Modal(opts);
+    if (!window.__testModals) window.__testModals = [];
+    window.__testModals.push(modal);
+    return window.__testModals.length - 1;
+  }, options);
+}
+
+async function modalState(page, index) {
+  return page.evaluate((i) => {
+    const modal = window.__testModals[i];
+    const title = modal.title;
+    return {
+      isOpen: modal.isOpen,
+      titleId: title?.id ?? null,
+      labelledBy: modal.overlay.getAttribute('aria-labelledby'),
+      overlayOpen: modal.overlay.classList.contains('open'),
+      listenersBound: modal.documentListenersBound,
+    };
+  }, index);
+}
+
+async function destroyTestModals(page) {
+  await page.evaluate(() => {
+    (window.__testModals || []).forEach((m) => m.destroy());
+    window.__testModals = [];
+  });
+}
+
+test.describe('modal a11y hygiene (D8 / D10 / D11)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/modal/test.html');
+    await page.waitForFunction(() => typeof window.Modal === 'function');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await destroyTestModals(page);
+  });
+
+  test('each instance gets a unique title id wired to aria-labelledby', async ({
+    page,
+  }) => {
+    const a = await createModal(page, { title: 'Settings', content: '<p>A</p>' });
+    const b = await createModal(page, { title: 'Confirm', content: '<p>B</p>' });
+
+    const stateA = await modalState(page, a);
+    const stateB = await modalState(page, b);
+
+    expect(stateA.titleId).toMatch(/^modal-title-\d+$/);
+    expect(stateB.titleId).toMatch(/^modal-title-\d+$/);
+    expect(stateA.titleId).not.toBe(stateB.titleId);
+    expect(stateA.labelledBy).toBe(stateA.titleId);
+    expect(stateB.labelledBy).toBe(stateB.titleId);
+
+    const duplicateScan = await page.evaluate(() => {
+      const ids = Array.from(document.querySelectorAll('.modal-title')).map(
+        (el) => el.id,
+      );
+      return { ids, uniqueCount: new Set(ids).size };
+    });
+    expect(duplicateScan.uniqueCount).toBe(duplicateScan.ids.length);
+    expect(duplicateScan.ids).toContain(stateA.titleId);
+    expect(duplicateScan.ids).toContain(stateB.titleId);
+  });
+
+  test('updateTitle on a title-less modal assigns the instance id', async ({
+    page,
+  }) => {
+    const index = await createModal(page, {
+      title: null,
+      content: '<p>No title yet</p>',
+      footerButtons: [{ label: 'Close', type: 'primary' }],
+    });
+
+    let state = await modalState(page, index);
+    expect(state.titleId).toBeNull();
+    expect(state.labelledBy).toBeNull();
+
+    await page.evaluate((i) => {
+      window.__testModals[i].updateTitle('Added later');
+    }, index);
+
+    state = await modalState(page, index);
+    expect(state.titleId).toMatch(/^modal-title-\d+$/);
+    expect(state.labelledBy).toBe(state.titleId);
+  });
+
+  test('Escape closes only the top stacked modal', async ({ page }) => {
+    const a = await createModal(page, {
+      title: 'Bottom',
+      content: '<p>Bottom modal</p>',
+    });
+    const b = await createModal(page, {
+      title: 'Top',
+      content: '<p>Top modal</p>',
+    });
+
+    await page.evaluate((i) => window.__testModals[i].open(), a);
+    await page.evaluate((i) => window.__testModals[i].open(), b);
+
+    expect((await modalState(page, a)).isOpen).toBe(true);
+    expect((await modalState(page, b)).isOpen).toBe(true);
+
+    await page.keyboard.press('Escape');
+
+    expect((await modalState(page, b)).isOpen).toBe(false);
+    expect((await modalState(page, a)).isOpen).toBe(true);
+
+    await page.keyboard.press('Escape');
+
+    expect((await modalState(page, a)).isOpen).toBe(false);
+    expect((await modalState(page, b)).isOpen).toBe(false);
+  });
+
+  test('close detaches document keydown listeners; reopen reattaches', async ({
+    page,
+  }) => {
+    const index = await createModal(page, {
+      title: 'Once',
+      content: '<p>Listener lifecycle</p>',
+    });
+
+    expect((await modalState(page, index)).listenersBound).toBe(false);
+
+    await page.evaluate((i) => window.__testModals[i].open(), index);
+    expect((await modalState(page, index)).listenersBound).toBe(true);
+
+    await page.evaluate((i) => window.__testModals[i].close(), index);
+    expect((await modalState(page, index)).listenersBound).toBe(false);
+
+    await page.evaluate((i) => window.__testModals[i].open(), index);
+    expect((await modalState(page, index)).listenersBound).toBe(true);
+  });
+
+  test('hash links use smooth scroll by default', async ({ page }) => {
+    await page.evaluate(() => {
+      const orig = Element.prototype.scrollIntoView;
+      window.__scrollIntoViewCalls = [];
+      Element.prototype.scrollIntoView = function scrollIntoViewSpy(opts) {
+        window.__scrollIntoViewCalls.push(
+          opts && typeof opts === 'object' ? { ...opts } : opts,
+        );
+        return orig.apply(this, arguments);
+      };
+    });
+
+    await page.evaluate(() => {
+      const template = document.querySelector('#help-modal-template');
+      const modal = window.Modal.createHelpModal({
+        title: 'Help',
+        content: template.content.cloneNode(true),
+      });
+      window.__testModals = [modal];
+      modal.open();
+    });
+
+    await page.locator('.modal-overlay.open a[href="#features"]').click();
+
+    const calls = await page.evaluate(() => window.__scrollIntoViewCalls);
+    expect(calls.some((c) => c?.behavior === 'smooth')).toBe(true);
+  });
+
+  test('hash links skip smooth scroll when reduced motion is requested', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.evaluate(() => {
+      const orig = Element.prototype.scrollIntoView;
+      window.__scrollIntoViewCalls = [];
+      Element.prototype.scrollIntoView = function scrollIntoViewSpy(opts) {
+        window.__scrollIntoViewCalls.push(
+          opts && typeof opts === 'object' ? { ...opts } : opts,
+        );
+        return orig.apply(this, arguments);
+      };
+    });
+
+    await page.evaluate(() => {
+      const template = document.querySelector('#help-modal-template');
+      const modal = window.Modal.createHelpModal({
+        title: 'Help',
+        content: template.content.cloneNode(true),
+      });
+      window.__testModals = [modal];
+      modal.open();
+    });
+
+    await page.locator('.modal-overlay.open a[href="#features"]').click();
+
+    const calls = await page.evaluate(() => window.__scrollIntoViewCalls);
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((c) => c?.behavior !== 'smooth')).toBe(true);
+    expect(calls.some((c) => c?.behavior === 'auto')).toBe(true);
+  });
+});
+
+for (const colorScheme of ['light', 'dark']) {
+  test.describe(`modal axe — ${colorScheme}`, () => {
+    test.use({ colorScheme });
+
+    test('open titled modal has no axe violations', async ({ page }) => {
+      await page.goto('/components/modal/test.html');
+      await page.waitForFunction(() => typeof window.Modal === 'function');
+
+      await page.evaluate(() => {
+        const modal = new window.Modal({
+          title: 'Settings',
+          content: '<p class="body-medium">Temperature and thinking.</p>',
+          footerButtons: [{ label: 'Close', type: 'primary' }],
+        });
+        window.__testModals = [modal];
+        modal.open();
+      });
+
+      await expectNoAxeViolations(page, '.modal-overlay.open');
+      await page.evaluate(() => {
+        (window.__testModals || []).forEach((m) => m.destroy());
+        window.__testModals = [];
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes #19, #21, and #22 (D8, D10, D11 from the ChatCPT WCAG 2.2 AA audit).

Stacked or retained modal overlays no longer share `id="modal-title"`, leave document keydown handlers attached after close, or ignore `prefers-reduced-motion` on in-content hash links.

## Changes
Title ids follow the dropdown pattern: `modal-title-${n}` per instance, with `aria-labelledby` pointing at that id (omitted until a title exists).

Escape and focus-trap listeners attach in `open()` and detach in `close()`. Escape closes only the top of `openModalStack`, so a confirm dialog on top of settings does not dismiss both.

In-modal hash links use `scrollIntoView({ behavior: 'auto' })` when `prefers-reduced-motion: reduce`. Default motion is unchanged.

Overlays still stay in the DOM after close, which is the existing reopen API. Unique ids make that safe. D9 (translated accessible names) is a separate contract change and is not in this PR.

## Test plan
- [x] Two constructed modals have distinct title ids; `aria-labelledby` matches
- [x] Open A then B; Escape closes B only, then A
- [x] `close()` clears document listeners; `open()` reattaches
- [x] Help-modal TOC link uses smooth scroll by default and `auto` under reduced motion
- [x] axe on an open titled modal in light and dark (`npm test`)
- [ ] Keyboard walkthrough on `components/modal/test.html`

ChatCPT does not hardcode `modal-title`. After merge, the app needs a submodule bump; no constructor API change here.
