### PR TITLE
fix(a11y): add optional accessible-name overrides

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -631,7 +631,7 @@ const dropdown = new Dropdown(selector, options);
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `items` | Array | `[]` | Array of `{value, label}` objects |
-| `placeholder` | String | `'Select option'` | Placeholder text |
+| `placeholder` | String | `'Select option'` | Placeholder text. Also the combobox accessible name when nothing is selected; pass an already-translated string. |
 | `selectedValue` | String | `null` | Initial selected value |
 | `width` | String/Number | `'auto'` | Fixed width (ignored if `growToFit` is true) |
 | `growToFit` | Boolean | `false` | Auto-resize to fit content |
@@ -697,6 +697,9 @@ const slider = new NumericSlider(selector, options);
 | `continuousUpdates` | Boolean | `false` | If `true`, fires `onChange` continuously during drag (throttled by `throttleMs`). Final value always sent on drag end. |
 | `throttleMs` | Number | `16` | Throttle interval in ms for continuous updates (~60fps at 16ms). Only applies when `continuousUpdates` is `true`. |
 | `disabled` | Boolean | `false` | If `true`, disables the slider |
+| `handleLabel` | String | `'Value'` | `aria-label` for the single-value handle. Pass an already-translated string. |
+| `minHandleLabel` | String | `'Minimum value'` | `aria-label` for the range min handle. |
+| `maxHandleLabel` | String | `'Maximum value'` | `aria-label` for the range max handle. |
 | `onChange` | Function | `null` | Callback `(value, source)` when value changes. Fires on drag end (always), track click, keyboard, and during drag if `continuousUpdates` is `true`. |
 | `onInputChange` | Function | `null` | Callback `(value, source)` when value changes via input field |
 
@@ -864,6 +867,7 @@ const modal = new Modal(options);
 | `footerButtons` | Array | `null` | Array of button configs `[{label, type, onClick}]`. If `null`, footer is hidden |
 | `closeOnOverlayClick` | Boolean | `true` | If `true`, clicking overlay closes modal |
 | `closeOnEscape` | Boolean | `true` | If `true`, pressing Escape closes modal |
+| `closeButtonLabel` | String | `'Close modal'` | Accessible name for the header close button. Pass an already-translated string; no i18n runtime in the DS. |
 | `onOpen` | Function | `null` | Callback triggered when modal opens. Receives `(modal)` instance |
 | `onClose` | Function | `null` | Callback triggered when modal closes. Receives `(modal)` instance |
 

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -44,7 +44,7 @@ const dropdown = new Dropdown('#my-dropdown', {
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `items` | Array | `[]` | Array of objects with `value` and `label` properties. |
-| `placeholder` | String | `'Select option'` | Text displayed when no item is selected. |
+| `placeholder` | String | `'Select option'` | Text displayed when no item is selected. This is also the combobox accessible name until a value is chosen, so pass an already-translated string. |
 | `selectedValue` | String | `null` | Initial selected value. |
 | `width` | String/Number | `'auto'` | Fixed width of the dropdown (e.g., `200`, `'100%'`). Ignored if `growToFit` is true. |
 | `growToFit` | Boolean | `false` | If `true`, the dropdown automatically resizes to fit the selected content. |
@@ -64,7 +64,7 @@ const dropdown = new Dropdown('#my-dropdown', {
 
 Select-only combobox pattern (APG):
 
-- Toggle is a `<button role="combobox">` with `aria-haspopup="listbox"`, `aria-expanded`, and `aria-controls` pointing at the popup.
+- Toggle is a `<button role="combobox">` with `aria-haspopup="listbox"`, `aria-expanded`, and `aria-controls` pointing at the popup. The accessible name comes from the visible label (`placeholder` when nothing is selected). There is no separate i18n runtime; pass a translated `placeholder`.
 - Popup panel is `role="listbox"`; the layout wrapper uses `role="presentation"` so options are owned by the listbox.
 - Options are plain elements with `role="option"` and `tabindex="-1"` (not `<button>`).
 - Every option exposes `aria-selected="true"` or `"false"`; the checkmark SVG is decorative (`aria-hidden`) and is not the only selection cue.

--- a/components/modal/README.md
+++ b/components/modal/README.md
@@ -46,6 +46,7 @@ modal.open();
 | `footerButtons` | Array | `null` | Array of button configs `[{label, type, onClick}]`. If `null`, footer is hidden. |
 | `closeOnOverlayClick` | Boolean | `true` | If `true`, clicking overlay closes modal. |
 | `closeOnEscape` | Boolean | `true` | If `true`, pressing Escape closes modal. |
+| `closeButtonLabel` | String | `'Close modal'` | Accessible name for the header close button. Pass an already-translated string; the component has no i18n runtime. |
 | `onOpen` | Function | `null` | Callback triggered when modal opens. Receives `(modal)` instance. |
 | `onClose` | Function | `null` | Callback triggered when modal closes. Receives `(modal)` instance. |
 
@@ -406,6 +407,7 @@ The modal component includes:
 - **Keyboard Navigation**: Escape key closes modal
 - **Focus Trap**: Tab and Shift+Tab cycle only among focusable elements inside the dialog; background siblings are marked `inert` while open
 - **Body Scroll Lock**: Prevents background scrolling when modal is open
+- **Translated names**: pass `closeButtonLabel` (and footer `label`s) as already-translated strings. Defaults stay English when omitted.
 
 ## Dependencies
 

--- a/components/modal/modal.js
+++ b/components/modal/modal.js
@@ -109,6 +109,7 @@ class Modal {
       footerButtons: options.footerButtons || null, // Array of button configs or null to hide footer
       closeOnOverlayClick: options.closeOnOverlayClick !== undefined ? options.closeOnOverlayClick : true,
       closeOnEscape: options.closeOnEscape !== undefined ? options.closeOnEscape : true,
+      closeButtonLabel: options.closeButtonLabel || 'Close modal',
       onOpen: options.onOpen || null,
       onClose: options.onClose || null,
       ...options
@@ -150,7 +151,10 @@ class Modal {
       this.closeButton = document.createElement('button');
       this.closeButton.className = 'modal-close-button';
       this.closeButton.setAttribute('type', 'button');
-      this.closeButton.setAttribute('aria-label', 'Close modal');
+      this.closeButton.setAttribute(
+        'aria-label',
+        this.config.closeButtonLabel || 'Close modal',
+      );
       this.closeButton.innerHTML = this.getCloseIcon();
       this.header.appendChild(this.closeButton);
     }

--- a/components/numeric-slider/README.md
+++ b/components/numeric-slider/README.md
@@ -74,6 +74,9 @@ const rangeSlider = new NumericSlider('#my-range-slider', {
 | `continuousUpdates` | Boolean | `false` | If `true`, fires `onChange` continuously during dragging (throttled by `throttleMs`). If `false` (default), `onChange` only fires on drag end, track click, and keyboard interaction. Final value is always sent on drag end regardless of this setting. |
 | `throttleMs` | Number | `16` | Throttle interval in milliseconds for continuous updates during drag (~60fps at 16ms). Only applies when `continuousUpdates` is `true`. Lower values = more frequent updates but potentially lower performance. |
 | `disabled` | Boolean | `false` | If `true`, disables the slider and all input fields. |
+| `handleLabel` | String | `'Value'` | `aria-label` for the single-value handle. Pass an already-translated string. |
+| `minHandleLabel` | String | `'Minimum value'` | `aria-label` for the range slider's min handle. |
+| `maxHandleLabel` | String | `'Maximum value'` | `aria-label` for the range slider's max handle. |
 | `onChange` | Function | `null` | Callback triggered when value changes. Receives `(value, source)` where `value` is the new value(s) and `source` indicates the source of change (`'min'`, `'max'`, `'single'`, or `null`). By default, fires on drag end, track click, and keyboard interaction. If `continuousUpdates` is `true`, also fires during drag (throttled). |
 | `onInputChange` | Function | `null` | Callback triggered when value changes via input field. Receives `(value, source)` where `value` is the new value(s) and `source` indicates which input changed (`'min'`, `'max'`, or `'single'`). |
 
@@ -298,7 +301,7 @@ The slider automatically validates and corrects values:
 
 ## Accessibility
 
-- Each handle is the slider: `role="slider"` with `aria-valuemin` / `aria-valuemax` / `aria-valuenow` (always a single number), `aria-valuetext`, `aria-orientation="horizontal"`, and `aria-label`.
+- Each handle is the slider: `role="slider"` with `aria-valuemin` / `aria-valuemax` / `aria-valuenow` (always a single number), `aria-valuetext`, `aria-orientation="horizontal"`, and `aria-label` (`handleLabel` / `minHandleLabel` / `maxHandleLabel`; English defaults when omitted).
 - The `.numeric-slider-wrapper` is presentational only (no role, no tabindex) so there is one tab stop per handle and no nested interactive.
 - Range mode: each thumb exposes its own `aria-valuenow`; values are never comma-joined.
 - Disabled: handles use `aria-disabled="true"` and `tabindex="-1"` (plus the native `disabled` attribute).

--- a/components/numeric-slider/numeric-slider.js
+++ b/components/numeric-slider/numeric-slider.js
@@ -54,6 +54,9 @@ class NumericSlider {
       onChange: options.onChange || null,
       onInputChange: options.onInputChange || null,
       disabled: options.disabled || false,
+      handleLabel: options.handleLabel || 'Value',
+      minHandleLabel: options.minHandleLabel || 'Minimum value',
+      maxHandleLabel: options.maxHandleLabel || 'Maximum value',
       ...options
     };
 
@@ -167,7 +170,7 @@ class NumericSlider {
       this.minHandle.setAttribute('type', 'button');
       this.applyHandleSliderRole(this.minHandle, {
         value: this.values[0],
-        label: 'Minimum value',
+        label: this.config.minHandleLabel || 'Minimum value',
       });
 
       // Max handle
@@ -179,7 +182,7 @@ class NumericSlider {
       this.maxHandle.setAttribute('type', 'button');
       this.applyHandleSliderRole(this.maxHandle, {
         value: this.values[1],
-        label: 'Maximum value',
+        label: this.config.maxHandleLabel || 'Maximum value',
       });
 
       this.track.appendChild(this.filled);
@@ -195,7 +198,7 @@ class NumericSlider {
       this.handle.setAttribute('type', 'button');
       this.applyHandleSliderRole(this.handle, {
         value: this.values,
-        label: 'Value',
+        label: this.config.handleLabel || 'Value',
       });
 
       this.track.appendChild(this.filled);

--- a/tests/accessible-names.spec.js
+++ b/tests/accessible-names.spec.js
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * D9: optional accessible-name overrides. English remains the default.
+ * Consumers pass already-translated strings; the DS has no i18n runtime.
+ */
+
+test.describe('modal closeButtonLabel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/modal/test.html');
+    await page.waitForFunction(() => typeof window.Modal === 'function');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.evaluate(() => {
+      (window.__testModals || []).forEach((m) => m.destroy());
+      window.__testModals = [];
+    });
+  });
+
+  test('defaults to English Close modal', async ({ page }) => {
+    const label = await page.evaluate(() => {
+      const modal = new window.Modal({
+        title: 'Settings',
+        content: '<p>Body</p>',
+      });
+      window.__testModals = [modal];
+      return modal.closeButton.getAttribute('aria-label');
+    });
+    expect(label).toBe('Close modal');
+  });
+
+  test('uses closeButtonLabel when provided', async ({ page }) => {
+    const label = await page.evaluate(() => {
+      const modal = new window.Modal({
+        title: 'Ajustes',
+        content: '<p>Cuerpo</p>',
+        closeButtonLabel: 'Cerrar modal',
+      });
+      window.__testModals = [modal];
+      return modal.closeButton.getAttribute('aria-label');
+    });
+    expect(label).toBe('Cerrar modal');
+  });
+});
+
+test.describe('slider handle labels', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/numeric-slider/test.html');
+    await page.waitForFunction(() => window.testSliders?.singleDefault);
+  });
+
+  test('defaults remain English', async ({ page }) => {
+    const labels = await page.evaluate(() => {
+      const single = document.querySelector(
+        '#slider-single-default .numeric-slider-handle',
+      );
+      const range = Array.from(
+        document.querySelectorAll('#slider-range-default .numeric-slider-handle'),
+      );
+      return {
+        single: single?.getAttribute('aria-label'),
+        min: range[0]?.getAttribute('aria-label'),
+        max: range[1]?.getAttribute('aria-label'),
+      };
+    });
+    expect(labels.single).toBe('Value');
+    expect(labels.min).toBe('Minimum value');
+    expect(labels.max).toBe('Maximum value');
+  });
+
+  test('accepts translated handle labels', async ({ page }) => {
+    const labels = await page.evaluate(() => {
+      const singleRoot = document.createElement('div');
+      const rangeRoot = document.createElement('div');
+      document.body.append(singleRoot, rangeRoot);
+      const single = new window.NumericSlider(singleRoot, {
+        type: 'single',
+        value: 50,
+        handleLabel: 'Temperatura',
+      });
+      const range = new window.NumericSlider(rangeRoot, {
+        type: 'range',
+        value: [20, 80],
+        minHandleLabel: 'Valor mínimo',
+        maxHandleLabel: 'Valor máximo',
+      });
+      window.__testSlidersExtra = [single, range];
+      return {
+        single: single.handle.getAttribute('aria-label'),
+        min: range.minHandle.getAttribute('aria-label'),
+        max: range.maxHandle.getAttribute('aria-label'),
+      };
+    });
+    expect(labels.single).toBe('Temperatura');
+    expect(labels.min).toBe('Valor mínimo');
+    expect(labels.max).toBe('Valor máximo');
+
+    await page.evaluate(() => {
+      (window.__testSlidersExtra || []).forEach((s) => s.destroy());
+    });
+  });
+});
+
+test.describe('dropdown placeholder is the accessible name', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/components/dropdown/test.html');
+    await page.waitForFunction(() => window.testDropdowns?.basic);
+  });
+
+  test('default placeholder is Select option', async ({ page }) => {
+    const name = await page.locator('#dropdown-basic .dropdown-toggle').getAttribute(
+      'aria-labelledby',
+    );
+    const text = await page.locator(`#${name}`).textContent();
+    expect(text).toBe('Select option');
+  });
+
+  test('custom placeholder becomes the combobox name', async ({ page }) => {
+    const name = await page.locator('#dropdown-custom .dropdown-toggle').getAttribute(
+      'aria-labelledby',
+    );
+    const text = await page.locator(`#${name}`).textContent();
+    expect(text).toBe('Dropdown Toggle');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #20 (D9 from the ChatCPT WCAG 2.2 AA audit).

Modal and slider now accept optional accessible-name overrides so consumers can pass already-translated strings. English defaults stay when the options are omitted. There is no i18n runtime in the design system.

## Changes
- Modal: `closeButtonLabel` (default `'Close modal'`)
- Slider: `handleLabel`, `minHandleLabel`, `maxHandleLabel` (defaults `'Value'`, `'Minimum value'`, `'Maximum value'`)
- Dropdown: no new option. `placeholder` is already the combobox accessible name when nothing is selected; README / `agents.md` now say to pass a translated string.

Existing constructors keep working. ChatCPT should pass `t(...)` after the submodule bump (settings close button, model dropdown placeholder). The temperature slider already replaces `aria-label` with `aria-labelledby`, so it does not need `handleLabel`.

This PR is independent of #24 (D8/D10/D11). Both touch `modal.js` / the modal README, so rebase this branch if #24 lands first.

## Test plan
- [x] Modal default close label is `Close modal`; override is used when provided
- [x] Slider default handle labels stay English; translated overrides apply to single and range
- [x] Dropdown default placeholder is `Select option`; custom placeholder is the combobox name
- [x] `npm test` (existing slider / dropdown / contrast suites unchanged)
