### PR TITLE
fix(a11y): dark-adapt stroke semantic tokens (D12)

### DIFF
--- a/colors/README.md
+++ b/colors/README.md
@@ -74,5 +74,9 @@ Semantic text and focus tokens are chosen to meet WCAG 2.2 AA against `Backgroun
 | `--Colors-Text-Body-Lighter` | ≥ 4.5:1 (body text) | Use at full opacity. **Do not fade this token** with `opacity` — layering transparency will drop it below 4.5:1. |
 | `--Colors-Text-Body-Light` | ≥ 4.5:1 | Also used for input placeholders; kept one step stronger than Lighter. |
 
-`npm test` includes `tests/contrast-tokens.spec.js`, which measures these ratios in light and dark.
+### Stroke tokens in dark mode
+
+`--Colors-Stroke-*` are remapped in the dark block onto dark neutrals / primary steps (not the light near-white scale). Prefer these semantic stroke tokens for borders and dividers so components adapt automatically; avoid hardcoding `Neutral-100`…`550` for borders if you need theming.
+
+`npm test` includes `tests/contrast-tokens.spec.js`, which measures text/focus ratios and asserts stroke tokens dark-adapt.
 

--- a/colors/colors.css
+++ b/colors/colors.css
@@ -316,17 +316,22 @@
     --Colors-Icon-Strong: var(--Colors-Base-Neutral-00);
     --Colors-Icon-Primary: var(--Colors-Base-Primary-700);
 
-    /* Stroke Colors */
-    --Colors-Stroke-Default: var(--Colors-Base-Neutral-200);
-    --Colors-Stroke-Lighter: var(--Colors-Base-Neutral-100);
-    --Colors-Stroke-Light: var(--Colors-Base-Neutral-150);
-    --Colors-Stroke-Medium: var(--Colors-Base-Neutral-300);
-    --Colors-Stroke-Strong: var(--Colors-Base-Neutral-400);
-    --Colors-Stroke-Stronger: var(--Colors-Base-Neutral-550);
-    --Colors-Stroke-Primary: var(--Colors-Base-Primary-600);
-    --Colors-Stroke-Primary-Light: var(--Colors-Base-Primary-350);
-    --Colors-Stroke-Primary-Medium: var(--Colors-Base-Primary-500);
-    --Colors-Stroke-Primary-Dark: var(--Colors-Base-Primary-800);
-    --Colors-Stroke-Background: var(--Colors-Base-Neutral-20);
+    /* Stroke Colors (Elevated Dark Mode)
+       Light mode kept near-white neutrals for borders on white surfaces.
+       Those same steps glow on dark backgrounds, so remap onto the dark
+       neutral / primary scales while preserving Lighter → Stronger rank
+       (closer to Main-Top → more contrast). Aligned with input/box dark
+       borders (Neutral-1250…1100) and A7's Primary-450 focus token (D12). */
+    --Colors-Stroke-Background: var(--Colors-Base-Neutral-1300);
+    --Colors-Stroke-Lighter: var(--Colors-Base-Neutral-1250);
+    --Colors-Stroke-Light: var(--Colors-Base-Neutral-1200);
+    --Colors-Stroke-Default: var(--Colors-Base-Neutral-1150);
+    --Colors-Stroke-Medium: var(--Colors-Base-Neutral-1100);
+    --Colors-Stroke-Strong: var(--Colors-Base-Neutral-1000);
+    --Colors-Stroke-Stronger: var(--Colors-Base-Neutral-900);
+    --Colors-Stroke-Primary: var(--Colors-Base-Primary-450);
+    --Colors-Stroke-Primary-Light: var(--Colors-Base-Primary-500);
+    --Colors-Stroke-Primary-Medium: var(--Colors-Base-Primary-450);
+    --Colors-Stroke-Primary-Dark: var(--Colors-Base-Primary-600);
   }
 }

--- a/components/button/button.css
+++ b/components/button/button.css
@@ -52,6 +52,9 @@
         --Colors-Buttons-Secondary-Hover-Text: var(--Colors-Base-Primary-400);
         --Colors-Buttons-Secondary-Pressed: var(--Colors-Base-Primary-500);
         --Colors-Buttons-Secondary-Pressed-Text: var(--Colors-Base-Primary-500);
+        /* Tertiary Default is the border color (Neutral-300 in light). Without a
+           dark remap it stays near-white — same class of bug as D12 stroke tokens. */
+        --Colors-Buttons-Tertiary-Default: var(--Colors-Base-Neutral-1100);
         --Colors-Buttons-Tertiary-Default-Background: var(--Colors-Base-Neutral-Alphas-1200-25);
         --Colors-Buttons-Tertiary-Default-Text: var(--Colors-Base-Neutral-500);
         --Colors-Buttons-Tertiary-Hover: var(--Colors-Base-Neutral-1100);

--- a/tests/contrast-tokens.spec.js
+++ b/tests/contrast-tokens.spec.js
@@ -3,6 +3,7 @@ import { test, expect } from '@playwright/test';
 /**
  * A7 / A8 — measure semantic token contrast against Backgrounds-Main-Top
  * (and secondary button text on the same surface) in light and dark.
+ * D12 — assert stroke / tertiary-border tokens dark-adapt (not near-white).
  */
 
 function contrastRatio(fgHex, bgHex) {
@@ -16,6 +17,15 @@ function contrastRatio(fgHex, bgHex) {
   const L1 = rel(fgHex);
   const L2 = rel(bgHex);
   return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+}
+
+/** Relative luminance 0–1 from #rrggbb. */
+function relativeLuminance(hex) {
+  const h = hex.replace('#', '');
+  const rgb = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255);
+  const f = (c) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
 }
 
 async function readTokens(page) {
@@ -49,6 +59,11 @@ async function readTokens(page) {
       bodyLighter: sample('var(--Colors-Text-Body-Lighter)'),
       bodyLight: sample('var(--Colors-Text-Body-Light)'),
       secondaryText: sample('var(--Colors-Buttons-Secondary-Default-Text)'),
+      strokeDefault: sample('var(--Colors-Stroke-Default)'),
+      strokeLight: sample('var(--Colors-Stroke-Light)'),
+      strokeStrong: sample('var(--Colors-Stroke-Strong)'),
+      strokePrimary: sample('var(--Colors-Stroke-Primary)'),
+      tertiaryDefault: sample('var(--Colors-Buttons-Tertiary-Default)'),
     };
   });
 }
@@ -109,3 +124,53 @@ for (const colorScheme of ['light', 'dark']) {
     });
   });
 }
+
+test.describe('stroke tokens dark-adapt (D12)', () => {
+  test('dark Stroke-Default / Light / Strong are not the light near-white scale', async ({
+    browser,
+  }) => {
+    const lightCtx = await browser.newContext({ colorScheme: 'light' });
+    const darkCtx = await browser.newContext({ colorScheme: 'dark' });
+    const lightPage = await lightCtx.newPage();
+    const darkPage = await darkCtx.newPage();
+    await lightPage.goto('/tests/fixtures/contrast-tokens.html');
+    await darkPage.goto('/tests/fixtures/contrast-tokens.html');
+    await Promise.all([
+      lightPage.waitForFunction(() =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue('--Colors-Stroke-Default')
+          .trim(),
+      ),
+      darkPage.waitForFunction(() =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue('--Colors-Stroke-Default')
+          .trim(),
+      ),
+    ]);
+
+    const light = await readTokens(lightPage);
+    const dark = await readTokens(darkPage);
+
+    expect(dark.strokeDefault).not.toBe(light.strokeDefault);
+    expect(dark.strokeLight).not.toBe(light.strokeLight);
+    expect(dark.strokeStrong).not.toBe(light.strokeStrong);
+
+    // On dark Main-Top, adapted strokes must be darker than the light-mode
+    // near-white values (relative luminance much lower).
+    expect(relativeLuminance(dark.strokeDefault)).toBeLessThan(0.2);
+    expect(relativeLuminance(dark.strokeLight)).toBeLessThan(0.2);
+    expect(relativeLuminance(light.strokeDefault)).toBeGreaterThan(0.7);
+
+    // Stronger rank: Strong more luminous than Default on dark (more contrast).
+    expect(relativeLuminance(dark.strokeStrong)).toBeGreaterThan(
+      relativeLuminance(dark.strokeDefault),
+    );
+
+    // Tertiary Default is the border color — same near-white failure class.
+    expect(dark.tertiaryDefault).not.toBe(light.tertiaryDefault);
+    expect(relativeLuminance(dark.tertiaryDefault)).toBeLessThan(0.2);
+
+    await lightCtx.close();
+    await darkCtx.close();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #23 ([a11y][D12]). Dark-mode `--Colors-Stroke-*` tokens no longer copy the light near-white scale, so borders/dividers stop glowing on dark surfaces. **Visual change for all DS consumers** — please confirm with design-system owners before merge (same process as A7/A8).

Also dark-adapts `--Colors-Buttons-Tertiary-Default` (the tertiary border color), which stayed `Neutral-300` in dark and was the ChatCPT local workaround.

## Token changes (dark only; light unchanged)

| Token | Before (same as light) | After |
|---|---|---|
| `--Colors-Stroke-Background` | Neutral-20 | **Neutral-1300** |
| `--Colors-Stroke-Lighter` | Neutral-100 | **Neutral-1250** |
| `--Colors-Stroke-Light` | Neutral-150 | **Neutral-1200** |
| `--Colors-Stroke-Default` | Neutral-200 | **Neutral-1150** |
| `--Colors-Stroke-Medium` | Neutral-300 | **Neutral-1100** |
| `--Colors-Stroke-Strong` | Neutral-400 | **Neutral-1000** |
| `--Colors-Stroke-Stronger` | Neutral-550 | **Neutral-900** |
| `--Colors-Stroke-Primary` | Primary-600 | **Primary-450** |
| `--Colors-Stroke-Primary-Light` | Primary-350 | **Primary-500** |
| `--Colors-Stroke-Primary-Medium` | Primary-500 | **Primary-450** |
| `--Colors-Stroke-Primary-Dark` | Primary-800 | **Primary-600** |
| `--Colors-Buttons-Tertiary-Default` | Neutral-300 (unchanged in dark) | **Neutral-1100** |

Values align with existing dark input/box borders and A7’s Primary-450 focus token. Lighter → Stronger rank is preserved (closer to Main-Top → more contrast).

## Notes for consumers

- After submodule bump, ChatCPT can remove:
  - `app.css` tertiary border override (`--Colors-Buttons-Tertiary-Default`)
  - rest-pill darkening if it was only compensating for non-adaptive strokes
- Components that already hardcode dark borders (e.g. input’s Neutral-1250) are unchanged; semantic Stroke consumers (modal dividers, tables, horizontal-card dashed borders, etc.) will pick this up automatically.

## Test plan

- [x] `npm test` — 48/48, including new D12 regression in `tests/contrast-tokens.spec.js` (dark strokes ≠ light near-white; Strong > Default luminance; tertiary border adapts)
- [ ] Design-system owner visual review in dark mode (`colors/test.html`, modal, table, input, tertiary button)
- [ ] After submodule bump: remove ChatCPT local stroke/tertiary workarounds and spot-check borders

Made with [Cursor](https://cursor.com)