### PR TITLE
fix(a11y): dark-adapt stroke tokens for dark mode

### DIFF
--- a/colors/README.md
+++ b/colors/README.md
@@ -74,5 +74,9 @@ Semantic text and focus tokens are chosen to meet WCAG 2.2 AA against `Backgroun
 | `--Colors-Text-Body-Lighter` | ≥ 4.5:1 (body text) | Use at full opacity. **Do not fade this token** with `opacity` — layering transparency will drop it below 4.5:1. |
 | `--Colors-Text-Body-Light` | ≥ 4.5:1 | Also used for input placeholders; kept one step stronger than Lighter. |
 
-`npm test` includes `tests/contrast-tokens.spec.js`, which measures these ratios in light and dark.
+### Stroke tokens in dark mode
+
+`--Colors-Stroke-*` are remapped in the dark block onto dark neutrals / primary steps (not the light near-white scale). Prefer these semantic stroke tokens for borders and dividers so components adapt automatically; avoid hardcoding `Neutral-100`…`550` for borders if you need theming.
+
+`npm test` includes `tests/contrast-tokens.spec.js`, which measures text/focus ratios and asserts stroke tokens dark-adapt.
 

--- a/colors/colors.css
+++ b/colors/colors.css
@@ -316,17 +316,22 @@
     --Colors-Icon-Strong: var(--Colors-Base-Neutral-00);
     --Colors-Icon-Primary: var(--Colors-Base-Primary-700);
 
-    /* Stroke Colors */
-    --Colors-Stroke-Default: var(--Colors-Base-Neutral-200);
-    --Colors-Stroke-Lighter: var(--Colors-Base-Neutral-100);
-    --Colors-Stroke-Light: var(--Colors-Base-Neutral-150);
-    --Colors-Stroke-Medium: var(--Colors-Base-Neutral-300);
-    --Colors-Stroke-Strong: var(--Colors-Base-Neutral-400);
-    --Colors-Stroke-Stronger: var(--Colors-Base-Neutral-550);
-    --Colors-Stroke-Primary: var(--Colors-Base-Primary-600);
-    --Colors-Stroke-Primary-Light: var(--Colors-Base-Primary-350);
-    --Colors-Stroke-Primary-Medium: var(--Colors-Base-Primary-500);
-    --Colors-Stroke-Primary-Dark: var(--Colors-Base-Primary-800);
-    --Colors-Stroke-Background: var(--Colors-Base-Neutral-20);
+    /* Stroke Colors (Elevated Dark Mode)
+       Light mode kept near-white neutrals for borders on white surfaces.
+       Those same steps glow on dark backgrounds, so remap onto the dark
+       neutral / primary scales while preserving Lighter → Stronger rank
+       (closer to Main-Top → more contrast). Aligned with input/box dark
+       borders (Neutral-1250…1100) and A7's Primary-450 focus token (D12). */
+    --Colors-Stroke-Background: var(--Colors-Base-Neutral-1300);
+    --Colors-Stroke-Lighter: var(--Colors-Base-Neutral-1250);
+    --Colors-Stroke-Light: var(--Colors-Base-Neutral-1200);
+    --Colors-Stroke-Default: var(--Colors-Base-Neutral-1150);
+    --Colors-Stroke-Medium: var(--Colors-Base-Neutral-1100);
+    --Colors-Stroke-Strong: var(--Colors-Base-Neutral-1000);
+    --Colors-Stroke-Stronger: var(--Colors-Base-Neutral-900);
+    --Colors-Stroke-Primary: var(--Colors-Base-Primary-450);
+    --Colors-Stroke-Primary-Light: var(--Colors-Base-Primary-500);
+    --Colors-Stroke-Primary-Medium: var(--Colors-Base-Primary-450);
+    --Colors-Stroke-Primary-Dark: var(--Colors-Base-Primary-600);
   }
 }

--- a/colors/colors.css
+++ b/colors/colors.css
@@ -330,8 +330,8 @@
     --Colors-Stroke-Strong: var(--Colors-Base-Neutral-1000);
     --Colors-Stroke-Stronger: var(--Colors-Base-Neutral-900);
     --Colors-Stroke-Primary: var(--Colors-Base-Primary-450);
-    --Colors-Stroke-Primary-Light: var(--Colors-Base-Primary-500);
-    --Colors-Stroke-Primary-Medium: var(--Colors-Base-Primary-450);
+    --Colors-Stroke-Primary-Light: var(--Colors-Base-Primary-350);
+    --Colors-Stroke-Primary-Medium: var(--Colors-Base-Primary-500);
     --Colors-Stroke-Primary-Dark: var(--Colors-Base-Primary-600);
   }
 }

--- a/components/button/button.css
+++ b/components/button/button.css
@@ -52,6 +52,9 @@
         --Colors-Buttons-Secondary-Hover-Text: var(--Colors-Base-Primary-400);
         --Colors-Buttons-Secondary-Pressed: var(--Colors-Base-Primary-500);
         --Colors-Buttons-Secondary-Pressed-Text: var(--Colors-Base-Primary-500);
+        /* Tertiary Default is the border color (Neutral-300 in light). Without a
+           dark remap it stays near-white — same class of bug as D12 stroke tokens. */
+        --Colors-Buttons-Tertiary-Default: var(--Colors-Base-Neutral-1100);
         --Colors-Buttons-Tertiary-Default-Background: var(--Colors-Base-Neutral-Alphas-1200-25);
         --Colors-Buttons-Tertiary-Default-Text: var(--Colors-Base-Neutral-500);
         --Colors-Buttons-Tertiary-Hover: var(--Colors-Base-Neutral-1100);

--- a/tests/contrast-tokens.spec.js
+++ b/tests/contrast-tokens.spec.js
@@ -3,6 +3,7 @@ import { test, expect } from '@playwright/test';
 /**
  * A7 / A8 — measure semantic token contrast against Backgrounds-Main-Top
  * (and secondary button text on the same surface) in light and dark.
+ * D12 — assert stroke / tertiary-border tokens dark-adapt (not near-white).
  */
 
 function contrastRatio(fgHex, bgHex) {
@@ -16,6 +17,15 @@ function contrastRatio(fgHex, bgHex) {
   const L1 = rel(fgHex);
   const L2 = rel(bgHex);
   return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+}
+
+/** Relative luminance 0–1 from #rrggbb. */
+function relativeLuminance(hex) {
+  const h = hex.replace('#', '');
+  const rgb = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255);
+  const f = (c) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
 }
 
 async function readTokens(page) {
@@ -49,6 +59,11 @@ async function readTokens(page) {
       bodyLighter: sample('var(--Colors-Text-Body-Lighter)'),
       bodyLight: sample('var(--Colors-Text-Body-Light)'),
       secondaryText: sample('var(--Colors-Buttons-Secondary-Default-Text)'),
+      strokeDefault: sample('var(--Colors-Stroke-Default)'),
+      strokeLight: sample('var(--Colors-Stroke-Light)'),
+      strokeStrong: sample('var(--Colors-Stroke-Strong)'),
+      strokePrimary: sample('var(--Colors-Stroke-Primary)'),
+      tertiaryDefault: sample('var(--Colors-Buttons-Tertiary-Default)'),
     };
   });
 }
@@ -109,3 +124,53 @@ for (const colorScheme of ['light', 'dark']) {
     });
   });
 }
+
+test.describe('stroke tokens dark-adapt (D12)', () => {
+  test('dark Stroke-Default / Light / Strong are not the light near-white scale', async ({
+    browser,
+  }) => {
+    const lightCtx = await browser.newContext({ colorScheme: 'light' });
+    const darkCtx = await browser.newContext({ colorScheme: 'dark' });
+    const lightPage = await lightCtx.newPage();
+    const darkPage = await darkCtx.newPage();
+    await lightPage.goto('/tests/fixtures/contrast-tokens.html');
+    await darkPage.goto('/tests/fixtures/contrast-tokens.html');
+    await Promise.all([
+      lightPage.waitForFunction(() =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue('--Colors-Stroke-Default')
+          .trim(),
+      ),
+      darkPage.waitForFunction(() =>
+        getComputedStyle(document.documentElement)
+          .getPropertyValue('--Colors-Stroke-Default')
+          .trim(),
+      ),
+    ]);
+
+    const light = await readTokens(lightPage);
+    const dark = await readTokens(darkPage);
+
+    expect(dark.strokeDefault).not.toBe(light.strokeDefault);
+    expect(dark.strokeLight).not.toBe(light.strokeLight);
+    expect(dark.strokeStrong).not.toBe(light.strokeStrong);
+
+    // On dark Main-Top, adapted strokes must be darker than the light-mode
+    // near-white values (relative luminance much lower).
+    expect(relativeLuminance(dark.strokeDefault)).toBeLessThan(0.2);
+    expect(relativeLuminance(dark.strokeLight)).toBeLessThan(0.2);
+    expect(relativeLuminance(light.strokeDefault)).toBeGreaterThan(0.7);
+
+    // Stronger rank: Strong more luminous than Default on dark (more contrast).
+    expect(relativeLuminance(dark.strokeStrong)).toBeGreaterThan(
+      relativeLuminance(dark.strokeDefault),
+    );
+
+    // Tertiary Default is the border color — same near-white failure class.
+    expect(dark.tertiaryDefault).not.toBe(light.tertiaryDefault);
+    expect(relativeLuminance(dark.tertiaryDefault)).toBeLessThan(0.2);
+
+    await lightCtx.close();
+    await darkCtx.close();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #23 (D12). Dark mode redefined every `--Colors-Stroke-*` token to the same light-mode near-white neutrals, so borders and dividers glowed on dark surfaces. ChatCPT already patched two consumers locally.

**Visual change for all DS consumers.** Design has signed off for ChatCPT Wave 4.

## Changes
Neutral strokes invert onto the dark scale, keeping Lighter → Stronger as increasing contrast against `Backgrounds-Main-Top` (`Neutral-1300`):

| Token | Light | Dark |
|---|---|---|
| Background | Neutral-20 | Neutral-1300 |
| Lighter | Neutral-100 | Neutral-1250 |
| Light | Neutral-150 | Neutral-1200 |
| Default | Neutral-200 | Neutral-1150 |
| Medium | Neutral-300 | Neutral-1100 |
| Strong | Neutral-400 | Neutral-1000 |
| Stronger | Neutral-550 | Neutral-900 |
| Primary | Primary-600 | Primary-450 (same step as A7 focus) |
| Primary-Light / Medium / Dark | 350 / 500 / 800 | 350 / 500 / 600 |

`--Colors-Buttons-Tertiary-Default` is the tertiary border (`Neutral-300` in light) and had the same miss. Dark now uses `Neutral-1100`, matching ChatCPT's existing override.

Look at the dark block in `colors/colors.css`. Components that already dark-adapt their own borders (boxes, tags, dropdown hover) keep those overrides.

## Test plan
- [x] `npm test` — stroke tokens in dark are not the light near-white scale; A7/A8 contrast tests still pass
- [x] `colors/test.html` in dark: stroke swatches sit on the dark neutrals, not `#E7EAF2` / `#F4F5F9`
- [x] Buttons, inputs, tables, modal header rules, dropdown hover in dark
- [ ] After merge: ChatCPT submodule bump; drop `app.css` tertiary-border override. Rest-pill uses `Stroke-Light` at 0.5 opacity, so that dark override may still be needed (grip vs hairline).
